### PR TITLE
Don't create version of unsaved record

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -106,7 +106,7 @@ module PaperTrail
       end
 
       def record_destroy
-        if switched_on?
+        if switched_on? and not new_record?
           versions.create merge_metadata(:event     => 'destroy',
                                          :object    => object_to_string(item_before_change),
                                          :whodunnit => PaperTrail.whodunnit)


### PR DESCRIPTION
Hi!

Thank you for great lib. We started using for auditing of our app and it works perfect. The only issue was that it tries to create version even if ActiveRecord object was not saved in database. In this rare case we see exception "ActiveRecord::RecordNotSaved: You cannot call create unless the parent is saved". 
Here is simple patch that eliminates such a cases.

To reproduce this you could get simple model with has_paper_trail and run this code :

<pre>
obj = SimpleModelWithPaperTrail.build
obj.destroy
</pre>


We are using Rails 2.3.8.

Thanks,
Mikl
