### PR TITLE
ActiveRecord::RecordNotSaved exception on destroy with Rails 3.0.2

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -107,9 +107,10 @@ module PaperTrail
 
       def record_destroy
         if switched_on? and not new_record?
-          versions.create merge_metadata(:event     => 'destroy',
-                                         :object    => object_to_string(item_before_change),
-                                         :whodunnit => PaperTrail.whodunnit)
+          Version.create merge_metadata(:item      => self,
+                                        :event     => 'destroy',
+                                        :object    => object_to_string(item_before_change),
+                                        :whodunnit => PaperTrail.whodunnit)
         end
       end
 


### PR DESCRIPTION
When you destroy a model in Rails 3.0.2 you get an Exception thrown (ActiveRecord::RecordNotSaved)

To fix this I don't use the versions.create method, instead I use the Version.create method with the "item" attribute.

By the way, great job with this gem, is a very usefull one.
