### PR TITLE
Order of versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Here's a helpful table showing what PaperTrail stores:
 
 PaperTrail stores the values in the Model Before column.  Most other auditing/versioning plugins store the After column.
 
+## Order of versions
+
+By default, versions are returned with the order `created_at ASC, id ASC`.
+
+You can override this:
+    class Article < ActiveRecord::Base
+      has_paper_trail :order => 'created_at DESC'
+    end
 
 ## Ignoring changes to certain attributes
 
@@ -303,7 +311,7 @@ PaperTrail automatically restores `:has_one` associations as they were at (actua
 
     >> treasure.update_attributes :amount => 153
     >> treasure.location.update_attributes :latitude => 54.321
-    
+
     >> t = treasure.versions.last.reify
     >> t.amount                         # 100
     >> t.location.latitude              # 12.345
@@ -333,13 +341,13 @@ Given these models:
       has_many :authors, :through => :authorships, :source => :person
       has_paper_trail
     end
-    
+
     class Authorship < ActiveRecord::Base
       belongs_to :book
       belongs_to :person
       has_paper_trail      # NOTE
     end
-    
+
     class Person < ActiveRecord::Base
       has_many :authorships, :dependent => :destroy
       has_many :books, :through => :authorships
@@ -362,7 +370,7 @@ But none of these will:
 Having said that, you can apparently get all these working (I haven't tested it myself) with this [monkey patch](http://stackoverflow.com/questions/2381033/how-to-create-a-full-audit-log-in-rails-for-every-table/2381411#2381411):
 
     # In config/initializers/core_extensions.rb or lib/core_extensions.rb
-    ActiveRecord::Associations::HasManyThroughAssociation.class_eval do 
+    ActiveRecord::Associations::HasManyThroughAssociation.class_eval do
       def delete_records(records)
         klass = @reflection.through_reflection.klass
         records.each do |associate|
@@ -372,7 +380,7 @@ Having said that, you can apparently get all these working (I haven't tested it 
     end
 
 The difference is the call to `destroy_all` instead of `delete_all` in [the original](http://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/has_many_through_association.rb#L76-81).
-    
+
 
 There may be a way to store authorship versions, probably using association callbacks, no matter how the collection is manipulated but I haven't found it yet.  Let me know if you do.
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -35,7 +35,7 @@ module PaperTrail
         cattr_accessor :paper_trail_active
         self.paper_trail_active = true
 
-        has_many :versions, :as => :item, :order => 'created_at ASC, id ASC'
+        has_many :versions, :as => :item, :order => (options[:order] || 'created_at ASC, id ASC')
 
         after_create  :record_create
         before_update :record_update
@@ -118,7 +118,7 @@ module PaperTrail
       def merge_metadata(data)
         # First we merge the model-level metadata in `meta`.
         meta.each do |k,v|
-          data[k] = 
+          data[k] =
             if v.respond_to?(:call)
               v.call(self)
             elsif v.is_a?(Symbol) && respond_to?(v)


### PR DESCRIPTION
I made a change to allow an optional :order to be passed with the has_paper_trail.

I also updated the README to explain said option.

This allows a user to specify the sort order of the versions of they like.
