### PR TITLE
Fixing versions creation without controller

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -63,8 +63,11 @@ module PaperTrail
   private
 
   # Thread-safe hash to hold PaperTrail's data.
+  # Initializing with needed default values.
   def self.paper_trail_store
-    Thread.current[:paper_trail] ||= {}
+    Thread.current[:paper_trail] ||= {
+      :request_enabled_for_controller => true
+    }
   end
 
   # Returns PaperTrail's configuration object.

--- a/test/paper_trail_test.rb
+++ b/test/paper_trail_test.rb
@@ -4,4 +4,24 @@ class PaperTrailTest < ActiveSupport::TestCase
   test 'Sanity test' do
     assert_kind_of Module, PaperTrail
   end
+
+  test 'create with plain model class' do
+    widget = Widget.create
+    assert_equal 1, widget.versions.length
+  end
+
+  test 'update with plain model class' do
+    widget = Widget.create
+    assert_equal 1, widget.versions.length
+    widget.update_attributes(:name => 'Bugle')
+    assert_equal 2, widget.versions.length
+  end
+
+  test 'destroy with plain model class' do
+    widget = Widget.create
+    assert_equal 1, widget.versions.length
+    widget.destroy
+    versions_for_widget = Version.with_item_keys('Widget', widget.id)
+    assert_equal 2, versions_for_widget.length
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,12 @@ ActiveRecord::Migrator.migrate File.expand_path("../dummy/db/migrate/", __FILE__
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
+# global setup block resetting Thread.current
+class ActiveSupport::TestCase
+  teardown do
+    Thread.current[:paper_trail] = nil
+  end
+end
 
 #
 # Helpers


### PR DESCRIPTION
Fixed a problem leading to not create a new version if tracked objects where initialized / modifed outside an controller.
(For instance in tests or on the rails console)

I additionally fixed a leakage between the tests.
