### PR TITLE
Support for rails 3.1

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -143,7 +143,7 @@ module PaperTrail
       end
 
       def item_before_change
-        self.clone.tap do |previous|
+        self.dup.tap do |previous|
           previous.id = id
           changed_attributes.each { |attr, before| previous[attr] = before }
         end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -212,11 +212,11 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     end
 
     should 'handle datetimes' do
-      assert_equal @date_time.to_time.utc, @previous.a_datetime.to_time.utc
+      assert_equal @date_time.to_time.utc.to_i, @previous.a_datetime.to_time.utc.to_i
     end
 
     should 'handle times' do
-      assert_equal @time, @previous.a_time
+      assert_equal @time.utc.to_i, @previous.a_time.utc.to_i
     end
 
     should 'handle dates' do
@@ -241,14 +241,14 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       end
 
       should 'restore all forward-compatible attributes' do
-        assert_equal    'Warble',               @last.reify.name
-        assert_equal    'The quick brown fox',  @last.reify.a_text
-        assert_equal    42,                     @last.reify.an_integer
-        assert_in_delta 153.01,                 @last.reify.a_float,   0.001
-        assert_in_delta 2.71828,                @last.reify.a_decimal, 0.00001
-        assert_equal    @date_time.to_time.utc, @last.reify.a_datetime.to_time.utc
-        assert_equal    @time,                  @last.reify.a_time
-        assert_equal    @date,                  @last.reify.a_date
+        assert_equal    'Warble',                    @last.reify.name
+        assert_equal    'The quick brown fox',       @last.reify.a_text
+        assert_equal    42,                          @last.reify.an_integer
+        assert_in_delta 153.01,                      @last.reify.a_float,   0.001
+        assert_in_delta 2.71828,                     @last.reify.a_decimal, 0.00001
+        assert_equal    @date_time.to_time.utc.to_i, @last.reify.a_datetime.to_time.utc.to_i
+        assert_equal    @time.utc.to_i,              @last.reify.a_time.utc.to_i
+        assert_equal    @date,                       @last.reify.a_date
         assert          @last.reify.a_boolean
       end
     end


### PR DESCRIPTION
I had issues with paper_trail and rails 3.1, this patch works for me and passes the tests for rails 3.1 and 3.0.x. As I see it the issue is caused by a frozen hash, duping instead of cloning worked for me.
