### PR TITLE
Fix for Rails 3.1+ IdentityMap

### DIFF
--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -96,7 +96,20 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         should 'have versions that are not live' do
           assert @widget.versions.map(&:reify).compact.all? { |w| !w.live? }
         end
+        
+        should 'not clobber the IdentityMap when reifying' do
+          module ::ActiveRecord
+            class IdentityMap
+              def self.without(&block)
+                @unclobbered = true
+                block.call
+              end 
+            end
+          end
 
+          @widget.versions.last.reify
+          assert ActiveRecord::IdentityMap.instance_variable_get("@unclobbered")
+        end
 
         context 'and has one associated object' do
           setup do


### PR DESCRIPTION
The IdentityMap is disabled by default, but is essentially a 2D hash of classname -> ID -> cached record.

Calling reify currently inserts an older record into the identity map to be returned on subsequent calls to find et al. This fix prevents reify from messing with the IM, preserving the desired behaviour, as far as I've been able to tell.
