### PR TITLE
Reify now defaults to :has_one => false

### DIFF
--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -32,7 +32,8 @@ class Version < ActiveRecord::Base
   #              sub-second datetimes if you want them).
   def reify(options = {})
     without_identity_map do
-      options.reverse_merge! :has_one => 3
+      options[:has_one] = 3 if options[:has_one] == true
+      options.reverse_merge! :has_one => false
 
       unless object.nil?
         attrs = YAML::load object

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -117,11 +117,17 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         context 'and has one associated object' do
           setup do
             @wotsit = @widget.create_wotsit :name => 'John'
-            @reified_widget = @widget.versions.last.reify
+          end
+          
+          should 'not copy the has_one association by default when reifying' do
+            reified_widget = @widget.versions.last.reify
+            assert_equal @wotsit, reified_widget.wotsit  # association hasn't been affected by reifying
+            assert_equal @wotsit, @widget.wotsit  # confirm that the association is correct
           end
 
-          should 'copy the has_one association when reifying' do
-            assert_nil @reified_widget.wotsit  # wotsit wasn't there at the last version
+          should 'copy the has_one association when reifying with :has_one => true' do
+            reified_widget = @widget.versions.last.reify(:has_one => true)
+            assert_nil reified_widget.wotsit  # wotsit wasn't there at the last version
             assert_equal @wotsit, @widget.wotsit  # wotsit came into being on the live object
           end
         end


### PR DESCRIPTION
Updated the `reify` method to default to `:has_one => false` rather than `:has_one => 3`, and allow passing in `:has_one => true` which uses the default 3 seconds. Also updated the test suite and readme accordingly.
