### PR TITLE
Changeset method returns {} (empty hash) for create and destroy actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ PaperTrail can restore `:has_one` associations as they were at (actually, 3 seco
 
     >> treasure.update_attributes :amount => 153
     >> treasure.location.update_attributes :latitude => 54.321
-    
+
     >> t = treasure.versions.last.reify(:has_one => true)
     >> t.amount                         # 100
     >> t.location.latitude              # 12.345
@@ -374,13 +374,13 @@ Given these models:
       has_many :authors, :through => :authorships, :source => :person
       has_paper_trail
     end
-    
+
     class Authorship < ActiveRecord::Base
       belongs_to :book
       belongs_to :person
       has_paper_trail      # NOTE
     end
-    
+
     class Person < ActiveRecord::Base
       has_many :authorships, :dependent => :destroy
       has_many :books, :through => :authorships
@@ -403,7 +403,7 @@ But none of these will:
 Having said that, you can apparently get all these working (I haven't tested it myself) with this [monkey patch](http://stackoverflow.com/questions/2381033/how-to-create-a-full-audit-log-in-rails-for-every-table/2381411#2381411):
 
     # In config/initializers/core_extensions.rb or lib/core_extensions.rb
-    ActiveRecord::Associations::HasManyThroughAssociation.class_eval do 
+    ActiveRecord::Associations::HasManyThroughAssociation.class_eval do
       def delete_records(records)
         klass = @reflection.through_reflection.klass
         records.each do |associate|
@@ -413,7 +413,7 @@ Having said that, you can apparently get all these working (I haven't tested it 
     end
 
 The difference is the call to `destroy_all` instead of `delete_all` in [the original](http://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/has_many_through_association.rb#L76-81).
-    
+
 
 There may be a way to store authorship versions, probably using association callbacks, no matter how the collection is manipulated but I haven't found it yet.  Let me know if you do.
 
@@ -458,7 +458,7 @@ There are two scenarios: diffing adjacent versions and diffing non-adjacent vers
 The best way to diff adjacent versions is to get PaperTrail to do it for you.  If you add an `object_changes` text column to your `versions` table, either at installation time with the `--with-changes` option or manually, PaperTrail will store the `changes` diff in each `update` version.  You can use the `version.changeset` method to retrieve it.  For example:
 
     >> widget = Widget.create :name => 'Bob'
-    >> widget.versions.last.changeset                # nil
+    >> widget.versions.last.changeset                # {}
     >> widget.update_attributes :name => 'Robert'
     >> widget.versions.last.changeset                # {'name' => ['Bob', 'Robert']}
 

--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -81,7 +81,13 @@ class Version < ActiveRecord::Base
 
   # Returns what changed in this version of the item.  Cf. `ActiveModel::Dirty#changes`.
   def changeset
-    YAML::load(object_changes) if Version.method_defined?(:object_changes) && object_changes
+    if Version.method_defined?(:object_changes)
+      if changes = object_changes
+        YAML::load(changes)
+      else
+        {}
+      end
+    end
   end
 
   # Returns who put the item into the state stored in this version.

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -61,7 +61,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       end
 
       should 'should not have changes' do
-        assert_nil @widget.versions.last.changeset
+        assert_equal Hash.new, @widget.versions.last.changeset
       end
 
       context 'and then updated without any changes' do


### PR DESCRIPTION
Changeset method returns {} (empty hash) for create and destroy actions if object_changes column defined but return nil if column does not exist.

I just thought that it will be better because often we need to call 'each' for 'changeset'.
And if 'changeset' will return {}, we don't have to check what it returns.

Like:

```
  if version.changeset
    version.changeset.each do |key, value|
      ...
```

Sorry that is not thought about it beforehand. 
