### PR TITLE
Add :on option to has_paper_trail method

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -50,9 +50,9 @@ module PaperTrail
                  :as         => :item,
                  :order      => "created_at ASC, #{self.primary_key} ASC"
 
-        after_create  :record_create
-        before_update :record_update
-        after_destroy :record_destroy
+        after_create  :record_create if !options[:on] || (options[:on] && options[:on].include?(:create))
+        before_update :record_update if !options[:on] || (options[:on] && options[:on].include?(:update))
+        after_destroy :record_destroy if !options[:on] || (options[:on] && options[:on].include?(:destroy))
       end
 
       # Switches PaperTrail off for this class.

--- a/test/dummy/app/models/document.rb
+++ b/test/dummy/app/models/document.rb
@@ -1,3 +1,4 @@
 class Document < ActiveRecord::Base
-  has_paper_trail :versions => :paper_trail_versions
+  has_paper_trail :versions => :paper_trail_versions,
+                  :on => [:create, :update]
 end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -812,7 +812,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     end
   end
 
-  context 'A model with a custom association' do
+  context 'A model with a custom association and "on" option' do
     setup do
       @doc = Document.create
       @doc.update_attributes :name => 'Doc 1'
@@ -830,6 +830,11 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       @doc.update_attributes :name => 'Doc 2'
       assert_equal 3, @doc.paper_trail_versions.length
       assert_equal 'Doc 1', @doc.previous_version.name
+    end
+
+    should 'not create new version after destroy' do
+      @doc.destroy
+      assert_equal 2, @doc.paper_trail_versions.length
     end
   end
 


### PR DESCRIPTION
What you think about :on option for setting events for tracking in has_paper_trail method? Like in acts_as_audited.
I think, sometimes it will be useful to tracking only certain events.
