### PR TITLE
Fixup part of 91eab1a6990169cbcc4f

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -48,7 +48,7 @@ module PaperTrail
         has_many self.versions_association_name,
                  :class_name => version_class_name,
                  :as         => :item,
-                 :order      => "created_at ASC, #{self.primary_key} ASC"
+                 :order      => "created_at ASC, #{self.version_class_name.constantize.primary_key} ASC"
 
         after_create  :record_create
         before_update :record_update


### PR DESCRIPTION
Here, it'll take the primary key of the object we're versioning and try to use it to sort the versions table, which is fails badly if they don't have the same name. (I did not add a test because I was not sure of how to do that.)

With that, I can do a `Foo.find(1).versions` again (the primary key of Foo being id_foo).

It still leaves the problem of reify failing because the belongs_to polymorphic seems to think that everyone has "id" as its primary key, which in my case, is, well, wrong, everyone has a `id_<model_name>` as a primary key.
