### PR TITLE
Changeset returns HashWithIndifferentAccess

### DIFF
--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -84,7 +84,7 @@ class Version < ActiveRecord::Base
   def changeset
     if self.class.column_names.include? 'object_changes'
       if changes = object_changes
-        YAML::load(changes)
+        HashWithIndifferentAccess[YAML::load(changes)]
       else
         {}
       end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -109,6 +109,10 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
           assert_equal ({'name' => ['Henry', 'Harry']}), @widget.versions.last.changeset
         end
 
+        should 'return changes with indifferent access' do
+          assert_equal (['Henry', 'Harry']), @widget.versions.last.changeset[:name]
+        end
+
         if defined?(ActiveRecord::IdentityMap) && ActiveRecord::IdentityMap.respond_to?(:without)
           should 'not clobber the IdentityMap when reifying' do
             module ActiveRecord::IdentityMap


### PR DESCRIPTION
Now 'changeset' mehtod returns HashWithIndifferentAccess.
In database in 'object_changes' column object stored as HashWithIndifferentAccess http://o7.no/nLjjEz but after YAML::load converted in Hash.
