### PR TITLE
add reify_to_after_change method

### DIFF
--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -54,7 +54,9 @@ class Version < ActiveRecord::Base
         if item
           model = item
         else
-          klass = retrieve_model_class_from_item_type
+          inheritance_column_name = item_type.constantize.inheritance_column
+          class_name = attrs[inheritance_column_name].blank? ? item_type : attrs[inheritance_column_name]
+          klass = class_name.constantize
           model = klass.new
         end
 
@@ -121,7 +123,9 @@ class Version < ActiveRecord::Base
   # regardless of whether this is the live model or the next version
   def reify_to_after_change(options = {})
     if self.next.nil?
-      retrieve_model_class_from_item_type.find(item_id)
+      inheritance_column_name = item_type.constantize.inheritance_column
+      class_name = attributes.include?(inheritance_column_name) ? attributes[inheritance_column_name] : item_type
+      class_name.constantize.find(item_id)
     else
       self.next.reify(options)
     end
@@ -164,11 +168,5 @@ class Version < ActiveRecord::Base
     end
   end
 
-
-  def retrieve_model_class_from_item_type
-    inheritance_column_name = item_type.constantize.inheritance_column
-    class_name = attrs[inheritance_column_name].blank? ? item_type : attrs[inheritance_column_name]
-    klass = class_name.constantize
-  end
 
 end


### PR DESCRIPTION
Hi,

First, thanks for creating this gem. It's undoubtedly saved me a ton of time. 

As I've been using it, I've added a small enhancement that I thought you might be interested in.

The use case is this. 

1) You create a model and record its version number (e.g. version 1).

2) You want to retrieve the model after it was created, but before any subsequent changes have been made. 

3) Now, you can call version.reify_to_after_change and you either get i) version_2.reified, or if that doesn't exist, ii) the live version.

Does that sound helpful? If you're interested, I'll make any tweaks you think necessary.

Thanks,

Evan 
