### PR TITLE
Add attr_accessible to Version

### DIFF
--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -1,6 +1,7 @@
 class Version < ActiveRecord::Base
   belongs_to :item, :polymorphic => true
   validates_presence_of :event
+  attr_accessible :item_type, :item_id, :event, :whodunnit, :object
 
   def self.with_item_keys(item_type, item_id)
     scoped(:conditions => { :item_type => item_type, :item_id => item_id })


### PR DESCRIPTION
Hi,

Just ran into this. We use `config.active_record.whitelist_attributes in our app to force the use a attr_accessible in our models. This is in our`application.rb`

```
# Don't allow any mass assignment without an attr_accessible.
config.active_record.whitelist_attributes = true
```

This impacts all ActiveRecord::Base models, such as Version.
