### PR TITLE
Added :skip option

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -40,6 +40,9 @@ module PaperTrail
         class_attribute :ignore
         self.ignore = ([options[:ignore]].flatten.compact || []).map &:to_s
 
+        class_attribute :skip
+        self.skip = ([options[:skip]].flatten.compact || []).map &:to_s
+
         class_attribute :only
         self.only = ([options[:only]].flatten.compact || []).map &:to_s
 
@@ -191,7 +194,7 @@ module PaperTrail
       end
 
       def object_to_string(object)
-        object.attributes.to_yaml
+        object.attributes.except(*self.class.skip).to_yaml
       end
 
       def changed_notably?
@@ -203,7 +206,7 @@ module PaperTrail
       end
 
       def changed_and_not_ignored
-        changed - self.class.ignore
+        changed - self.class.ignore - self.class.skip
       end
 
       def switched_on?

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -1,6 +1,7 @@
 class Article < ActiveRecord::Base
   has_paper_trail :ignore => :title,
                   :only => [:content],
+                  :skip => [:file_upload],
                   :meta   => {:answer => 42,
                               :action => :action_data_provider_method,
                               :question => Proc.new { "31 + 11 = #{31 + 11}" },

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -65,6 +65,7 @@ class SetUpTestTables < ActiveRecord::Migration
       t.string :title
       t.string :content
       t.string :abstract
+      t.string :file_upload
     end
 
     create_table :books, :force => true do |t|

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -28,7 +28,36 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       setup { @article.update_attributes :abstract => 'Other abstract'}
       should_not_change('the number of versions') { Version.count }
     end
+    
+    context 'which updates a skipped column' do
+      setup { @article.update_attributes :file_upload => 'Your data goes here' }
+      should_not_change('the number of versions') { Version.count }
+    end
+    
+    context 'which updates a skipped column and a selected column' do
+      setup { @article.update_attributes :file_upload => 'Your data goes here', :content => 'Some text here.' }
+      should_change('the number of versions', :by => 1) { Version.count }
 
+      should 'have stored only non-skipped attributes' do
+        assert_equal ({'content' => [nil, 'Some text here.']}), @article.versions.last.changeset
+      end
+      
+      context 'and when updated again' do
+        setup do
+          @article.update_attributes :file_upload => 'More data goes here', :content => 'More text here.'
+          @old_article = @article.versions.last
+        end
+        
+        should 'have removed the skipped attributes when saving the previous version' do
+          assert_equal nil, YAML::load(@old_article.object)['file_upload']
+        end
+        
+        should 'have kept the non-skipped attributes in the previous version' do
+          assert_equal 'Some text here.', YAML::load(@old_article.object)['content']
+        end
+      end
+    end
+    
   end
 
 


### PR DESCRIPTION
Fields specified with the :skip option will be completely ignored.

They won't create a new version if updated alone, and they won't
be included in the serialized version of the object if updated
with non-ignored and non-skipped columns.

Fixes #92
