### PR TITLE
Add separate test for :ignore attribute

### DIFF
--- a/test/dummy/app/models/legacy_widget.rb
+++ b/test/dummy/app/models/legacy_widget.rb
@@ -1,3 +1,4 @@
 class LegacyWidget < ActiveRecord::Base
-  has_paper_trail :version_name => 'custom_version'
+  has_paper_trail :ignore => :version,
+                  :version_name => 'custom_version'
 end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class HasPaperTrailModelTest < ActiveSupport::TestCase
 
-  context 'A record' do
+  context 'A record of model with defined "only" and "ignore" attributes' do
     setup { @article = Article.create }
 
     context 'which updates an ignored column' do
@@ -28,9 +28,16 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       setup { @article.update_attributes :abstract => 'Other abstract'}
       should_not_change('the number of versions') { Version.count }
     end
-
   end
 
+  context 'A record of model with defined "ignore" attribute' do
+    setup { @legacy_widget = LegacyWidget.create }
+
+    context 'which updates an ignored column' do
+      setup { @legacy_widget.update_attributes :version => 1 }
+      should_not_change('the number of versions') { Version.count }
+    end
+  end
 
   context 'A new record' do
     setup { @widget = Widget.new }


### PR DESCRIPTION
:ignore attribute hasn't been tested separately yet. We can do on this [line](https://github.com/airblade/paper_trail/blob/master/lib/paper_trail/has_paper_trail.rb#L41) everything
for ex:

```
self.ignore = [] 
```

and tests pass.

At this [context](https://github.com/airblade/paper_trail/blob/master/test/unit/model_test.rb#L5) :only and :ignore attributes have been tested. But :only attribute "overrides" :ignore attrbibute internally, and in that context ignored columns haven't difference with "non-selected" columns.

Maybe it isn't important: 
But it seems useless, when we have models with defined :ignore & :only together.
