### PR TITLE
Little doc fix for an example that doesn't work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,13 +327,13 @@ To find out who made a `version`'s object look that way, use `version.originator
 
 You can specify custom version subclasses with the `:class_name` option:
 
-    class Post < ActiveRecord::Base
-      has_paper_trail :class_name => 'PostVersion'
-    end
-
     class PostVersion < Version
       # custom behaviour, e.g:
       set_table_name :post_versions
+    end
+
+    class Post < ActiveRecord::Base
+      has_paper_trail :class_name => 'PostVersion'
     end
 
 This allows you to store each model's versions in a separate table, which is useful if you have a lot of versions being created.


### PR DESCRIPTION
lib/has_paper_trail.rb line 58, since 69b7a149, attempts to use this constant
immediately, so it needs to be defined before use. I don't see an easy way to
delay making that reference, so here's a tweak to so the example in the doc
works.
