### PR TITLE
":ignore_if" parameter for "#has_paper_trail"

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,13 @@ You can choose which events to track with the `on` option.  For example, to igno
     end
 
 
-## Choosing When Not To Save New Versions
+## Choosing When To Save New Versions
 
-You can choose the condition when not to add new versions with the `ignore_if` option. For example, to ignore non-US translations:
+You can choose the conditions when to add new versions with the `if` and `unless` options. For example, to save versions only for US non-draft translations:
 
     class Translation < ActiveRecord::Base
-      has_paper_trail :ignore_if => Proc.new { |t| t.language_code != 'US' }
+      has_paper_trail :if     => Proc.new { |t| t.language_code == 'US' },
+                      :unless => Proc.new { |t| t.type == 'DRAFT'       }
     end
 
 

--- a/test/dummy/app/models/translation.rb
+++ b/test/dummy/app/models/translation.rb
@@ -1,3 +1,4 @@
 class Translation < ActiveRecord::Base
-  has_paper_trail :ignore_if => Proc.new { |t| t.language_code != 'US' }
+  has_paper_trail :if     => Proc.new { |t| t.language_code == 'US' },
+                  :unless => Proc.new { |t| t.type == 'DRAFT'       }
 end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -108,6 +108,7 @@ class SetUpTestTables < ActiveRecord::Migration
       t.string    :headline
       t.string    :content
       t.string    :language_code
+      t.string    :type
     end
   end
 

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -68,7 +68,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     end
   end
 
-  context 'A record with defined "ignore_if" attribute' do
+  context 'A record with defined "if" and "unless" attributes' do
     setup { @translation = Translation.new :headline => 'Headline' }
 
     context 'for non-US translations' do
@@ -82,15 +82,31 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     end
 
     context 'for US translations' do
-      setup do
-        @translation.language_code = "US"
-        @translation.save
-      end
-      should_change('the number of versions', :by => 1) { Version.count }
+      setup { @translation.language_code = "US" }
 
-      context 'after update' do
-        setup { @translation.update_attributes :content => 'Content' }
+      context 'that are drafts' do
+        setup do
+          @translation.type = 'DRAFT'
+          @translation.save
+        end
+
+        should_not_change('the number of versions') { Version.count }
+
+        context 'after update' do
+          setup { @translation.update_attributes :content => 'Content' }
+          should_not_change('the number of versions') { Version.count }
+        end
+      end
+
+      context 'that are not drafts' do
+        setup { @translation.save }
+
         should_change('the number of versions', :by => 1) { Version.count }
+
+        context 'after update' do
+          setup { @translation.update_attributes :content => 'Content' }
+          should_change('the number of versions', :by => 1) { Version.count }
+        end
       end
     end
   end


### PR DESCRIPTION
It is possible to set a new parameter - "ignore_if" - when not to save new versions.
Might be useful when it is not required to store versions for all class instances. 
