### PR TITLE
Rename 'after' scope to 'following'

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -97,7 +97,7 @@ module PaperTrail
       def version_at(timestamp, reify_options={})
         # Because a version stores how its object looked *before* the change,
         # we need to look for the first version created *after* the timestamp.
-        v = send(self.class.versions_association_name).after(timestamp).first
+        v = send(self.class.versions_association_name).following(timestamp).first
         v ? v.reify(reify_options) : self
       end
 

--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -15,7 +15,7 @@ class Version < ActiveRecord::Base
     where(["#{self.primary_key} < ?", version.is_a?(self) ? version.id : version]).order("#{self.primary_key} DESC")
   }
 
-  scope :after, lambda { |timestamp|
+  scope :following, lambda { |timestamp|
     # TODO: is this :order necessary, considering its presence on the has_many :versions association?
     where(['created_at > ?', timestamp]).order("created_at ASC, #{self.primary_key} ASC")
   }


### PR DESCRIPTION
I just started using paper_trail and whenever I would try to use `record.version_at(timestamp)` I would get this error:

```
ArgumentError: wrong number of arguments (1 for 0)
from (__DELEGATE__):2:in `after'
```

I tracked it down to the after call in version_at and it seems it's conflicting with another `after` (maybe `Rails::Initializable::Initializer#after`?), anyway just renaming the scope to `following` fixes it for me.

I can't really explain how no one else would have come across since I would assume `version_at` would be called by at least one other person. The version of Rails I came across this was 3.1.1.

Thanks!

—Travis
