### PR TITLE
Remove hardcoded references to id and created_at fields

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -32,6 +32,14 @@ module PaperTrail
     paper_trail_store[:request_enabled_for_controller] = value
   end
 
+  def self.timestamp_field=(field_name)
+    PaperTrail.config.timestamp_field = field_name
+  end
+
+  def self.timestamp_field
+    PaperTrail.config.timestamp_field
+  end
+
   # Returns who is reponsible for any changes that occur.
   def self.whodunnit
     paper_trail_store[:whodunnit]

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -1,11 +1,12 @@
 module PaperTrail
   class Config
     include Singleton
-    attr_accessor :enabled
+    attr_accessor :enabled, :timestamp_field
  
     def initialize
       # Indicates whether PaperTrail is on or off.
-      @enabled = true
+      @enabled         = true
+      @timestamp_field = :created_at
     end
   end
 end

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -68,7 +68,7 @@ module PaperTrail
         has_many self.versions_association_name,
                  :class_name => version_class_name,
                  :as         => :item,
-                 :order      => "created_at ASC, #{self.version_class_name.constantize.primary_key} ASC"
+                 :order      => "#{PaperTrail.timestamp_field} ASC, #{self.version_class_name.constantize.primary_key} ASC"
 
         after_create  :record_create, :if => :save_version? if !options[:on] || options[:on].include?(:create)
         before_update :record_update, :if => :save_version? if !options[:on] || options[:on].include?(:update)

--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -17,7 +17,7 @@ class Version < ActiveRecord::Base
 
   scope :following, lambda { |timestamp|
     # TODO: is this :order necessary, considering its presence on the has_many :versions association?
-    where(['created_at > ?', timestamp]).order("created_at ASC, #{self.primary_key} ASC")
+    where(["#{PaperTrail.timestamp_field} > ?", timestamp]).order("#{PaperTrail.timestamp_field} ASC, #{self.primary_key} ASC")
   }
 
   # Restore the item from this version.
@@ -146,7 +146,7 @@ class Version < ActiveRecord::Base
         # but until PaperTrail knows which updates are "together" (e.g. parent and child being
         # updated on the same form), it's impossible to tell when the overall update started;
         # and therefore impossible to know when "just before" was.
-        if (child_as_it_was = child.version_at(created_at - lookback.seconds))
+        if (child_as_it_was = child.version_at(send(PaperTrail.timestamp_field) - lookback.seconds))
           child_as_it_was.attributes.each do |k,v|
             model.send(assoc.name).send :write_attribute, k.to_sym, v rescue nil
           end


### PR DESCRIPTION
The gem assumes the generated migration is run without modification and refers to id and created_at fields throughout.

The first two commits change the version model to use the class' primary key instead of referencing id directly.

The last commit adds a configuration option for "timestamp_field" which allows the user to specify the name of the field which is used to track when the version was created.
