### PR TITLE
Depend on sqlite3 not sqlite3-ruby as per instructions when installing sqlite3-ruby

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'shoulda',      '2.10.3'
-  s.add_development_dependency 'sqlite3-ruby', '~> 1.2'
+  s.add_development_dependency 'sqlite3',      '~> 1.2'
   s.add_development_dependency 'capybara',     '~> 1.0.0'
 end


### PR DESCRIPTION
Post-install message from sqlite3-ruby:

Hello! The sqlite3-ruby gem has changed it's name to just sqlite3.  Rather than
installing 'sqlite3-ruby', you should install 'sqlite3'.  Please update your
dependencies accordingly.

Thanks from the Ruby sqlite3 team!

<3 <3 <3 <3
