### PR TITLE
Support conditional paper trail on destroy

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -72,7 +72,7 @@ module PaperTrail
 
         after_create  :record_create, :if => :save_version? if !options[:on] || options[:on].include?(:create)
         before_update :record_update, :if => :save_version? if !options[:on] || options[:on].include?(:update)
-        after_destroy :record_destroy if !options[:on] || options[:on].include?(:destroy)
+        after_destroy :record_destroy, :if => :save_version? if !options[:on] || options[:on].include?(:destroy)
       end
 
       # Switches PaperTrail off for this class.

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -79,6 +79,15 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         setup { @translation.update_attributes :content => 'Content' }
         should_not_change('the number of versions') { Version.count }
       end
+
+      context 'after destroy' do
+        setup do
+          @translation.save!
+          @translation.destroy
+        end
+
+        should_not_change('the number of versions') { Version.count }
+      end
     end
 
     context 'for US translations' do
@@ -105,6 +114,15 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
 
         context 'after update' do
           setup { @translation.update_attributes :content => 'Content' }
+          should_change('the number of versions', :by => 1) { Version.count }
+        end
+
+        context 'after destroy' do
+          setup do
+            @translation.save!
+            @translation.destroy
+          end
+
           should_change('the number of versions', :by => 1) { Version.count }
         end
       end


### PR DESCRIPTION
Howdy!

Background: We have a paper-trailed `Contact` model which `has_many :email_addresses`. The `EmailAddress` model also has a paper trail. We have a custom way of undo-ing deletes of parents, and all their children.

Problem: If someone blanks out an email in the web UI, then we destroy that email row. But, we don't want a `EmailAddress` version to be created in that case.

Other problem: However, we _do_ want to save a version of both the `EmailAddress` and the `Contact`, when a contact is deleted.

Solution: Pass along the `:if` conditional to the destroy code. We have a conditional expression that knows the difference between the parent `Contact` delete, versus the one-off deletion of an `EmailAddress` due to blanking it out in the UI.

Thanks!
