### PR TITLE
create/update/destroy can now have custom events

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -65,6 +65,8 @@ module PaperTrail
         class_attribute :versions_association_name
         self.versions_association_name = options[:versions] || :versions
 
+        attr_accessor :custom_event
+
         has_many self.versions_association_name,
                  :class_name => version_class_name,
                  :as         => :item,
@@ -149,14 +151,14 @@ module PaperTrail
 
       def record_create
         if switched_on?
-          send(self.class.versions_association_name).create merge_metadata(:event => 'create', :whodunnit => PaperTrail.whodunnit)
+          send(self.class.versions_association_name).create merge_metadata(:event => custom_event || 'create', :whodunnit => PaperTrail.whodunnit)
         end
       end
 
       def record_update
         if switched_on? && changed_notably?
           data = {
-            :event     => 'update',
+            :event     => custom_event || 'update',
             :object    => object_to_string(item_before_change),
             :whodunnit => PaperTrail.whodunnit
           }
@@ -174,7 +176,7 @@ module PaperTrail
         if switched_on? and not new_record?
           version_class.create merge_metadata(:item_id   => self.id,
                                               :item_type => self.class.base_class.name,
-                                              :event     => 'destroy',
+                                              :event     => custom_event || 'destroy',
                                               :object    => object_to_string(item_before_change),
                                               :whodunnit => PaperTrail.whodunnit)
         end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1045,6 +1045,78 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     end
   end
 
+  context 'custom events' do
+    context 'on create' do
+      setup do
+        Fluxor.reset_callbacks :create
+        Fluxor.reset_callbacks :update
+        Fluxor.reset_callbacks :destroy
+        Fluxor.instance_eval <<-END
+          before_create :set_custom_event
+          has_paper_trail :on => [:create]
+        END
+        Fluxor.class_eval <<-END
+          def set_custom_event
+            self.custom_event = 'created'
+          end
+        END
+        @fluxor = Fluxor.create
+        @fluxor.update_attributes :name => 'blah'
+        @fluxor.destroy
+      end
+      should 'only have a version for the created event' do
+        assert_equal 1, @fluxor.versions.length
+        assert_equal 'created', @fluxor.versions.last.event
+      end
+    end
+    context 'on update' do
+      setup do
+        Fluxor.reset_callbacks :create
+        Fluxor.reset_callbacks :update
+        Fluxor.reset_callbacks :destroy
+        Fluxor.instance_eval <<-END
+          before_update :set_custom_event
+          has_paper_trail :on => [:update]
+        END
+        Fluxor.class_eval <<-END
+          def set_custom_event
+            self.custom_event = 'name_updated'
+          end
+        END
+        @fluxor = Fluxor.create
+        @fluxor.update_attributes :name => 'blah'
+        @fluxor.destroy
+      end
+      should 'only have a version for the name_updated event' do
+        assert_equal 1, @fluxor.versions.length
+        assert_equal 'name_updated', @fluxor.versions.last.event
+      end
+    end
+    context 'on destroy' do
+      setup do
+        Fluxor.reset_callbacks :create
+        Fluxor.reset_callbacks :update
+        Fluxor.reset_callbacks :destroy
+        Fluxor.instance_eval <<-END
+          before_destroy :set_custom_event
+          has_paper_trail :on => [:destroy]
+        END
+        Fluxor.class_eval <<-END
+          def set_custom_event
+            self.custom_event = 'destroyed'
+          end
+        END
+        @fluxor = Fluxor.create
+        @fluxor.update_attributes :name => 'blah'
+        @fluxor.destroy
+      end
+      should 'only have a version for the destroy event' do
+        assert_equal 1, @fluxor.versions.length
+        assert_equal 'destroyed', @fluxor.versions.last.event
+      end
+    end
+  end
+
   private
 
   # Updates `model`'s last version so it looks like the version was


### PR DESCRIPTION
I allows you to have custom events, this is useful when you want to track specific changes with a specific name, let's say that you have a model 'Sale' with some fields like 'price' 'sale_price', and you want to use an specific event when the 'price' changes, so you use something like:

```
class Sale
  before_update :set_custom_event
  has_paper_clip

  private
  def set_custom_event
    self.custom_event = 'price_changed' if price_changed?
  end
end
```
