### PR TITLE
Factor out version_key into its own method

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -68,11 +68,15 @@ module PaperTrail
         has_many self.versions_association_name,
                  :class_name => version_class_name,
                  :as         => :item,
-                 :order      => "#{PaperTrail.timestamp_field} ASC, #{self.version_class_name.constantize.primary_key} ASC"
+                 :order      => "#{PaperTrail.timestamp_field} ASC, #{self.version_key} ASC"
 
         after_create  :record_create, :if => :save_version? if !options[:on] || options[:on].include?(:create)
         before_update :record_update, :if => :save_version? if !options[:on] || options[:on].include?(:update)
         after_destroy :record_destroy if !options[:on] || options[:on].include?(:destroy)
+      end
+
+      def version_key
+        return self.version_class_name.constantize.primary_key
       end
 
       # Switches PaperTrail off for this class.


### PR DESCRIPTION
See Issue #177.  Perhaps this isn't the "right" fix for the problem I'm having, but it does clean up the code a bit and it will allow me to monkey patch paper_trail to suit my needs.
