### PR TITLE
controller metadata methods (user_for_paper_trail and info_for_paper_trail) should be evaluated only when paper_trail_enabled_for_controller is true.

### DIFF
--- a/lib/paper_trail/controller.rb
+++ b/lib/paper_trail/controller.rb
@@ -2,9 +2,9 @@ module PaperTrail
   module Controller
 
     def self.included(base)
+      base.before_filter :set_paper_trail_enabled_for_controller
       base.before_filter :set_paper_trail_whodunnit
       base.before_filter :set_paper_trail_controller_info
-      base.before_filter :set_paper_trail_enabled_for_controller
     end
 
     protected
@@ -57,7 +57,7 @@ module PaperTrail
 
     # Tells PaperTrail who is responsible for any changes that occur.
     def set_paper_trail_whodunnit
-      ::PaperTrail.whodunnit = user_for_paper_trail
+      ::PaperTrail.whodunnit = user_for_paper_trail if paper_trail_enabled_for_controller
     end
 
     # DEPRECATED: please use `set_paper_trail_whodunnit` instead.
@@ -69,7 +69,7 @@ module PaperTrail
     # Tells PaperTrail any information from the controller you want
     # to store alongside any changes that occur.
     def set_paper_trail_controller_info
-      ::PaperTrail.controller_info = info_for_paper_trail
+      ::PaperTrail.controller_info = info_for_paper_trail if paper_trail_enabled_for_controller
     end
 
   end

--- a/test/functional/controller_test.rb
+++ b/test/functional/controller_test.rb
@@ -68,4 +68,23 @@ class ControllerTest < ActionController::TestCase
     assert_equal '127.0.0.1',     versions_for_widget.last.ip
     assert_equal 'Rails Testing', versions_for_widget.last.user_agent
   end
+
+  test "controller metadata methods should get evaluated if paper trail is enabled for controller" do
+    @request.env['HTTP_USER_AGENT'] = 'User-Agent'
+    post :create, :widget => { :name => 'Flugel' }
+    assert PaperTrail.enabled_for_controller?
+    assert_equal 153, PaperTrail.whodunnit
+    assert PaperTrail.controller_info.present?
+    assert PaperTrail.controller_info.keys.include?(:ip)
+    assert PaperTrail.controller_info.keys.include?(:user_agent)
+  end
+
+  test "controller metadata methods should not get evaluated if paper trail is disabled for controller" do
+    @request.env['HTTP_USER_AGENT'] = 'Disable User-Agent'
+    post :create, :widget => { :name => 'Flugel' }
+    assert_equal 0, assigns(:widget).versions.length
+    assert !PaperTrail.enabled_for_controller?    
+    assert PaperTrail.whodunnit.nil?
+    assert PaperTrail.controller_info.nil?
+  end
 end


### PR DESCRIPTION
Added tests for same in functional/controller_test.rb
