### PR TITLE
fully qualify the Version class to prevent load-errors

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -39,7 +39,7 @@ module PaperTrail
         attr_accessor self.version_association_name
 
         class_attribute :version_class_name
-        self.version_class_name = options[:class_name] || 'Version'
+        self.version_class_name = options[:class_name] || '::Version'
 
         class_attribute :paper_trail_options
         self.paper_trail_options = options.dup


### PR DESCRIPTION
We use paper_trail inside engines and this causes load-errors because Rails will load the wrong file for the `Version` class. The exact error is:

```
     LoadError:
       Expected /project/lib/project/version.rb to define Project::Version
```

I patched paper_trail to fully qualify the constant name `"::Version"` this should have no effect on existing applications but fixed the problem for me.
