### PR TITLE
Support for PaperTrail.configure block

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -87,6 +87,10 @@ module PaperTrail
   def self.config
     @@config ||= PaperTrail::Config.instance
   end
+  
+  def self.configure
+    yield config
+  end
 
 end
 

--- a/test/unit/serializer_test.rb
+++ b/test/unit/serializer_test.rb
@@ -40,7 +40,9 @@ class SerializerTest < ActiveSupport::TestCase
 
   context 'Custom Serializer' do
     setup do
-      PaperTrail.config.serializer = CustomSerializer
+      PaperTrail.configure do |config|
+        config.serializer = CustomSerializer
+      end
 
       Fluxor.instance_eval <<-END
         has_paper_trail


### PR DESCRIPTION
Re: our discussion in https://github.com/airblade/paper_trail/pull/188, here is the implementation to support a configure block, along with a simple test. This would eliminate the need to continually add accessors to the PaperTrail module.
