### PR TITLE
Compatibility with serialized_attributes gem

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -82,7 +82,7 @@ module PaperTrail
       end
 
       # Used for Version#object attribute
-      def serialize_attributes(attributes)
+      def serialize_attributes_for_paper_trail(attributes)
         serialized_attributes.each do |key, coder|
           if attributes.key?(key)
             attributes[key] = coder.dump(attributes[key])
@@ -90,7 +90,7 @@ module PaperTrail
         end
       end
 
-      def unserialize_attributes(attributes)
+      def unserialize_attributes_for_paper_trail(attributes)
         serialized_attributes.each do |key, coder|
           if attributes.key?(key)
             attributes[key] = coder.load(attributes[key])
@@ -264,7 +264,7 @@ module PaperTrail
 
       def object_to_string(object)
         _attrs = object.attributes.except(*self.class.paper_trail_options[:skip]).tap do |attributes|
-          self.class.serialize_attributes attributes
+          self.class.serialize_attributes_for_paper_trail attributes
         end
         PaperTrail.serializer.dump(_attrs)
       end

--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -79,7 +79,7 @@ class Version < ActiveRecord::Base
           model = klass.new
         end
 
-        model.class.unserialize_attributes attrs
+        model.class.unserialize_attributes_for_paper_trail attrs
         attrs.each do |k, v|
           if model.respond_to?("#{k}=")
             model.send :write_attribute, k.to_sym, v


### PR DESCRIPTION
Hi,

I've been trying to use Paper Trail with the [serialized_attributes gem](https://github.com/technoweenie/serialized_attributes). After much pain and anguish, I figured out that both Paper Trail and SerializedAttributes define the same class method on the model: `serialize_attributes`. You can imagine the havoc this caused. =)

I think the best solution is to change the method names in Paper Trail. This is because the `serialize_attributes` method in the Serialized Attributes gem is a public interface. You must call this method in order to enable the gem. In Paper Trail, this method is only used internally. So it should be safe to change the method names in Paper Trail. Another advantage is that `serialize_attributes` is a pretty generic method name, which may interfere with other gems, so it's good to make the name more specific to Paper Trail.
