### PR TITLE
Make the create object work with custom serializer

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -189,7 +189,7 @@ module PaperTrail
           }
 
           if changed_notably? and version_class.column_names.include?('object_changes')
-            data[:object_changes] = changes_for_paper_trail.to_yaml
+            data[:object_changes] = PaperTrail.serializer.dump(changes_for_paper_trail)
           end
 
           send(self.class.versions_association_name).create merge_metadata(data)

--- a/test/unit/serializer_test.rb
+++ b/test/unit/serializer_test.rb
@@ -54,7 +54,7 @@ class SerializerTest < ActiveSupport::TestCase
       PaperTrail.config.serializer = PaperTrail::Serializers::Yaml
     end
 
-    should 'work with custom serializer' do
+    should 'reify with custom serializer' do
       # Normal behaviour
       assert_equal 2, @fluxor.versions.length
       assert_nil @fluxor.versions[0].reify
@@ -64,7 +64,13 @@ class SerializerTest < ActiveSupport::TestCase
       hash = {"widget_id" => nil,"name" =>"Some text.","id" =>1}
       assert_equal JSON.dump(hash), @fluxor.versions[1].object
       assert_equal hash, JSON.parse(@fluxor.versions[1].object)
+    end
 
+    should 'store object_changes' do
+      initial_changeset = {"name" => [nil, "Some text."], "id" => [nil, 1]}
+      second_changeset =  {"name"=>["Some text.", "Some more text."]}
+      assert_equal initial_changeset, @fluxor.versions[0].changeset
+      assert_equal second_changeset,  @fluxor.versions[1].changeset
     end
   end
 


### PR DESCRIPTION
The changeset from a create action was hardcoded to yaml, as the create stuff was added between the time I created the customserializer PR and it was merged
