### PR TITLE
Use class instead of module for the default serializers

### DIFF
--- a/lib/paper_trail/serializers/json.rb
+++ b/lib/paper_trail/serializers/json.rb
@@ -2,7 +2,7 @@ require 'active_support/json'
 
 module PaperTrail
   module Serializers
-    module Json
+    class Json
       def self.load(string)
         ActiveSupport::JSON.decode string
       end

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -2,7 +2,7 @@ require 'yaml'
 
 module PaperTrail
   module Serializers
-    module Yaml
+    class Yaml
       def self.load(string)
         YAML.load string
       end


### PR DESCRIPTION
Hi, I just tried out the new `PaperTrail::Serializers::Json` class... no wait, module. It turns out that in my app, I want to do some manipulation of the data before converting to JSON, so I tried subclassing `PaperTrail::Serializers::Json`, which obviously didn't work. I tried various combinations of including or extending the module, but I wasn't able to call `super`.

Ultimately, I just want to do something like this:

``` ruby
# Serializes data for PaperTrail as JSON, ignoring nil values
class MinimalJsonSerializer < PaperTrail::Serializers::Json
  def self.dump(hash)
    super(hash.reject {|_,v| v.nil?})
  end
end
```

This patch changes the two default serializers to classes rather than modules, making their functionality much easier to extend.
