### PR TITLE
Fix Gemfile to use 'https://rubygems.org'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Just a quick fix to get rid of the following deprecation warning:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
