### PR TITLE
Update has_paper_trail.rb

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -58,9 +58,8 @@ module PaperTrail
         self.versions_association_name = options[:versions] || :versions
 
         has_many self.versions_association_name,
-                 :class_name => version_class_name,
-                 :as         => :item,
-                 :order      => "#{PaperTrail.timestamp_field} ASC, #{self.version_key} ASC"
+                 lambda { |_model| order("#{PaperTrail.timestamp_field} ASC", "#{_model.class.version_key} ASC") },
+                 :class_name => self.version_class_name, :as => :item
                  
         after_create  :record_create, :if => :save_version? if !options[:on] || options[:on].include?(:create)
         before_update :record_update, :if => :save_version? if !options[:on] || options[:on].include?(:update)


### PR DESCRIPTION
revert the wrong order() syntax. introduced in 009d3bd4a371f6c93c765fb4ee754ed98608437e. it generates a wrong SQL query
