### PR TITLE
Problem with nil values in `#reify`

### DIFF
--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -80,6 +80,14 @@ class Version < ActiveRecord::Base
         end
 
         model.class.unserialize_attributes_for_paper_trail attrs
+
+        # Look for attributes that exist in the model and not in this version.
+        # These attributes should be set to nil.
+        (model.attribute_names - attrs.keys).each do |k|
+          attrs[k] = nil
+        end
+
+        # Set all the attributes in this version on the model
         attrs.each do |k, v|
           if model.respond_to?("#{k}=")
             model[k.to_sym] = v

--- a/test/custom_json_serializer.rb
+++ b/test/custom_json_serializer.rb
@@ -1,0 +1,13 @@
+# This custom serializer excludes nil values
+module CustomJsonSerializer
+  extend PaperTrail::Serializers::Json
+
+  def self.load(string)
+    parsed_value = super(string)
+    parsed_value.is_a?(Hash) ? parsed_value.reject { |k,v| k.blank? || v.blank? } : parsed_value
+  end
+
+  def self.dump(object)
+    object.is_a?(Hash) ? super(object.reject { |k,v| v.nil? }) : super
+  end
+end

--- a/test/unit/serializer_test.rb
+++ b/test/unit/serializer_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'custom_json_serializer'
 
 class SerializerTest < ActiveSupport::TestCase
 
@@ -29,7 +30,7 @@ class SerializerTest < ActiveSupport::TestCase
     end
   end
 
-  context 'Custom Serializer' do
+  context 'JSON Serializer' do
     setup do
       PaperTrail.configure do |config|
         config.serializer = PaperTrail::Serializers::Json
@@ -48,7 +49,7 @@ class SerializerTest < ActiveSupport::TestCase
       PaperTrail.config.serializer = PaperTrail::Serializers::Yaml
     end
 
-    should 'reify with custom serializer' do
+    should 'reify with JSON serializer' do
       # Normal behaviour
       assert_equal 2, @fluxor.versions.length
       assert_nil @fluxor.versions[0].reify
@@ -66,6 +67,48 @@ class SerializerTest < ActiveSupport::TestCase
     should 'store object_changes' do
       initial_changeset = {"name" => [nil, "Some text."], "id" => [nil, 1]}
       second_changeset =  {"name"=>["Some text.", "Some more text."]}
+      assert_equal initial_changeset, @fluxor.versions[0].changeset
+      assert_equal second_changeset,  @fluxor.versions[1].changeset
+    end
+  end
+
+  context 'Custom Serializer' do
+    setup do
+      PaperTrail.configure do |config|
+        config.serializer = CustomJsonSerializer
+      end
+
+      Fluxor.instance_eval <<-END
+        has_paper_trail
+      END
+
+      @fluxor = Fluxor.create
+      @original_fluxor_attributes = @fluxor.send(:item_before_change).attributes.reject { |k,v| v.nil? } # this is exactly what PaperTrail serializes
+      @fluxor.update_attributes :name => 'Some more text.'
+    end
+
+    teardown do
+      PaperTrail.config.serializer = PaperTrail::Serializers::Yaml
+    end
+
+    should 'reify with custom serializer' do
+      # Normal behaviour
+      assert_equal 2, @fluxor.versions.length
+      assert_nil @fluxor.versions[0].reify
+      assert_nil @fluxor.versions[1].reify.name
+
+      # Check values are stored as JSON.
+      assert_equal @original_fluxor_attributes, ActiveSupport::JSON.decode(@fluxor.versions[1].object)
+      # This test can't consistently pass in Ruby1.8 because hashes do no preserve order, which means the order of the
+      # attributes in the JSON can't be ensured.
+      if RUBY_VERSION.to_f >= 1.9
+        assert_equal ActiveSupport::JSON.encode(@original_fluxor_attributes), @fluxor.versions[1].object
+      end
+    end
+
+    should 'store object_changes' do
+      initial_changeset = {"id" => [nil, 1]}
+      second_changeset =  {"name"=>[nil, "Some more text."]}
       assert_equal initial_changeset, @fluxor.versions[0].changeset
       assert_equal second_changeset,  @fluxor.versions[1].changeset
     end

--- a/test/unit/serializers/mixin_json_test.rb
+++ b/test/unit/serializers/mixin_json_test.rb
@@ -1,17 +1,5 @@
 require 'test_helper'
-
-module CustomJsonSerializer
-  extend PaperTrail::Serializers::Json
-
-  def self.load(string)
-    parsed_value = super(string)
-    parsed_value.is_a?(Hash) ? parsed_value.reject { |k,v| k.blank? || v.blank? } : parsed_value
-  end
-
-  def self.dump(object)
-    object.is_a?(Hash) ? super(object.reject { |k,v| v.nil? }) : super
-  end
-end
+require 'custom_json_serializer'
 
 class MixinJsonTest < ActiveSupport::TestCase
 


### PR DESCRIPTION
I'm using a custom serializer that does not store nil values. I noticed that the attributes are stored correctly, but then not correctly reified back. For example:

``` ruby
previous version data: {id: 123}
current version data:  {id: 123, name: "Bob"}

model
#=> <#Person id: 123, name: "Bob">

model.previous_version
#Expected => <#Person id: 123, name: nil>
#Actual => <#Person id: 123, name: "Bob">
```

After some digging, I found that the problem is in `#reify`. The current version of the model is reused, and each attribute from the previous version is set on the current model. However, since "name" is not a key in the previous version, name was left as "Bob."

This was not a problem in the default serializers provided. Because they store everything, both versions of the models have all the same keys. For example:

``` ruby
previous version data: {id: 123, name: nil, dob: nil}
current version data:  {id: 123, name: "Bob", dob: nil}
```

This patch compares the keys between the current model and the previous version. If any keys are found to be missing, it puts them in as nil. This allows those attributes to be set to nil on the reified model.

I updated the serializer tests so they separately test the built-in JSON serializer as well as a custom serializer which doesn't store nil keys.
