### PR TITLE
fixed undefined method version_key for ActiveRecord::Associations::JoinD...

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -60,7 +60,7 @@ module PaperTrail
         attr_accessor :paper_trail_event
 
         has_many self.versions_association_name,
-                 lambda { |_model| order("#{PaperTrail.timestamp_field} ASC", "#{_model.class.version_key} ASC") },
+                 lambda { |_model| order("#{PaperTrail.timestamp_field} ASC", "#{primary_key} ASC") },
                  :class_name => self.version_class_name, :as => :item
                  
         after_create  :record_create, :if => :save_version? if !options[:on] || options[:on].include?(:create)


### PR DESCRIPTION
The missing version_key method error can be simulated by running a simple join on versions

Ex.: `Address.joins(:versions).where("unit_number = ':n'", :n => 1000).to_a`

Where the address and the custom version classes are defined as follows

``` ruby
class Address < ActiveRecord::Base
  has_paper_trail :class_name => 'AddressVersion', :on => [:update], :meta => {:unit_number => :unit_number, :house_number => :house_number, :house_suffix => :house_suffix}
end

class AddressVersion < Version
  self.table_name = :address_versions
  attr_accessible :unit_number, :house_number, :house_suffix, :event, :object, :whodunnit
end
```
