### PR TITLE
Skip any changed attributes marked to skip in the PaperTrail options

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -262,7 +262,7 @@ module PaperTrail
         end
         previous.tap do |prev|
           prev.id = id
-          changed_attributes.except(*self.class.paper_trail_options[:skip]).each { |attr, before| prev[attr] = before }
+          changed_attributes.select { |k,v| self.class.column_names.include?(k) }.each { |attr, before| prev[attr] = before }
         end
       end
 


### PR DESCRIPTION
I came across the same problem described in #224 when using paper_trail with acts-as-taggable-on, and have a (partial) solution.

The reason this happens is that acts-as-taggable-on [defines some code](https://github.com/mbleigh/acts-as-taggable-on/blob/master/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb#L319) that manually adds a non-database field to the `changed_attributes` collection. paper_trail then tries to assign this value directly to the record using the column accessor, resulting in the following error:

``` ruby
ActiveModel::MissingAttributeError (can't write unknown attribute `tag_list')
```

My solution to this is to exclude from `changed_attributes` any keys defined in the `:skip` options of paper_trail - identically to what happens soon after that in the process, when the object is serialised. The reason this is just a partial fix is that the `tag_list` attribute still needs to be specified in the "skip" options for paper_trail. I don't really see a way around this short of acts-as-taggable-on changing how it behaves, but I'm very open to any suggestions.
