### PR TITLE
Detect protect attributes for rails 4

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -2,7 +2,6 @@ require 'paper_trail/cleaner'
 require 'paper_trail/config'
 require 'paper_trail/controller'
 require 'paper_trail/has_paper_trail'
-require 'paper_trail/version'
 
 require 'paper_trail/serializers/yaml'
 require 'paper_trail/serializers/json'
@@ -20,6 +19,10 @@ module PaperTrail
   # PaperTrail is enabled by default.
   def self.enabled?
     !!PaperTrail.config.enabled
+  end
+
+  def self.protected_attributes?
+    Rails.version < '4' || defined?(ProtectedAttributes)
   end
 
   # Returns `true` if PaperTrail is enabled for the request, `false` otherwise.
@@ -100,6 +103,9 @@ module PaperTrail
   end
 
 end
+
+require 'paper_trail/version'
+
 
 
 ActiveSupport.on_load(:active_record) do

--- a/lib/paper_trail/version.rb
+++ b/lib/paper_trail/version.rb
@@ -2,7 +2,7 @@ module PaperTrail
   class Version < ActiveRecord::Base
     belongs_to :item, :polymorphic => true
     validates_presence_of :event
-    attr_accessible :item_type, :item_id, :event, :whodunnit, :object, :object_changes if respond_to?(:attr_accessible)
+    attr_accessible :item_type, :item_id, :event, :whodunnit, :object, :object_changes if ::PaperTrail.protected_attributes?
 
     after_create :enforce_version_limit!
 

--- a/test/dummy/config/initializers/paper_trail.rb
+++ b/test/dummy/config/initializers/paper_trail.rb
@@ -1,5 +1,5 @@
 module PaperTrail
   class Version < ActiveRecord::Base
-    attr_accessible :created_at, :updated_at, :answer, :action, :question, :article_id, :ip, :user_agent, :title if respond_to?(:attr_accessible)
+    attr_accessible :created_at, :updated_at, :answer, :action, :question, :article_id, :ip, :user_agent, :title if ::PaperTrail.protected_attributes?
   end
 end


### PR DESCRIPTION
I'm not 100% sure about this approach, or hanging it off of `::PaperTrail`, but I needed this to prevent the following error in a Rails 4 application

```
activemodel-4.0.0/lib/active_model/deprecated_mass_assignment_security.rb:14:
in `attr_accessible': `attr_accessible` is extracted out of Rails into a gem. Please use new recommended protection model for params(strong
_parameters) or add `protected_attributes` to your Gemfile to use old one. (RuntimeError)
```

straight outta `lib/paper_trail/version.rb:5`
