### PR TITLE
Allow symbols to be passed to the 'on' option for single events

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -69,10 +69,11 @@ module PaperTrail
             :as         => :item,
             :order      => "#{PaperTrail.timestamp_field} ASC"
         end
-                 
-        after_create  :record_create, :if => :save_version? if !options[:on] || options[:on].include?(:create)
-        before_update :record_update, :if => :save_version? if !options[:on] || options[:on].include?(:update)
-        after_destroy :record_destroy, :if => :save_version? if !options[:on] || options[:on].include?(:destroy)
+
+        options_on = Array(options[:on])
+        after_create  :record_create, :if => :save_version? if options_on.empty? || options_on.include?(:create)
+        before_update :record_update, :if => :save_version? if options_on.empty? || options_on.include?(:update)
+        after_destroy :record_destroy, :if => :save_version? if options_on.empty? || options_on.include?(:destroy)
       end
 
       # Switches PaperTrail off for this class.

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1176,6 +1176,18 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         assert_equal 'destroy', @fluxor.versions.last.event
       end
     end
+    context 'allows a symbol to be passed' do
+      Fluxor.reset_callbacks :create
+      Fluxor.reset_callbacks :update
+      Fluxor.reset_callbacks :destroy
+      Fluxor.instance_evail <<-END
+        has_paper_trail :on => :create
+      END
+      should 'only have a version for hte create event' do
+        assert_equal 1, @fluxor.versions.length
+        assert_equal 'create', @fluxor.versions.last.event
+      end
+    end
   end
 
   context 'A model with column version and custom version_method' do


### PR DESCRIPTION
Generally in rails, when an option can be passed with an array of symbols, a symbol is allowed in place of a single element array.
