### PR TITLE
Don't try to write timestamp attributes just because the method exists; only write it if it is a real attribute.

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -268,7 +268,7 @@ module PaperTrail
         previous = self.dup
         # `dup` clears timestamps so we add them back.
         all_timestamp_attributes.each do |column|
-          previous[column] = send(column) if respond_to?(column) && !send(column).nil?
+          previous[column] = send(column) if attributes.has_key?(column.to_s) && !send(column).nil?
         end
         previous.tap do |prev|
           prev.id = id

--- a/test/dummy/app/models/wotsit.rb
+++ b/test/dummy/app/models/wotsit.rb
@@ -1,4 +1,8 @@
 class Wotsit < ActiveRecord::Base
   has_paper_trail
   belongs_to :widget
+
+  def created_on
+    created_at.to_date
+  end
 end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -582,6 +582,31 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
   end
 
 
+  context 'Timestamps' do
+    setup do
+      @wotsit = Wotsit.create! :name => 'wotsit'
+    end
+
+    should 'record timestamps' do
+      @wotsit.update_attributes! :name => 'changed'
+      assert_not_nil @wotsit.versions.last.reify.created_at
+      assert_not_nil @wotsit.versions.last.reify.updated_at
+    end
+
+    should 'not generate warning' do
+      # Tests that it doesn't try to write created_on as an attribute just because a created_on
+      # method exists.
+      warnings = capture(:stderr) {  # Deprecation warning in Rails 3.2
+        assert_nothing_raised {  # ActiveModel::MissingAttributeError in Rails 4
+          @wotsit.update_attributes! :name => 'changed'
+        }
+      }
+      assert_equal '', warnings
+    end
+
+  end
+
+
   context 'A subclass' do
     setup do
       @foo = FooWidget.create


### PR DESCRIPTION
This resolves this error you would get if you defined a created_on method (virtual attribute) in
your model, for example:

  DEPRECATION WARNING: You're trying to create an attribute `created_on'.  Writing arbitrary
  attributes on a model is deprecated. Please just use`attr_writer` etc.
