### PR TITLE
paper_trail for ActionController::API

### DIFF
--- a/lib/paper_trail/frameworks/rails.rb
+++ b/lib/paper_trail/frameworks/rails.rb
@@ -3,7 +3,7 @@ module PaperTrail
     module Controller
 
       def self.included(base)
-        if defined?(ActionController) && base == ActionController::Base
+        if defined?(ActionController) && (base == ActionController::Base || base == ActionController::API)
           base.before_filter :set_paper_trail_enabled_for_controller
           base.before_filter :set_paper_trail_whodunnit, :set_paper_trail_controller_info
         end


### PR DESCRIPTION
Including this to be able to use `info_for_paper_trail` via `:set_paper_trail_controller_info` when using ActionController::API.  
