### PR TITLE
PaperTrail.serializer#with_unformatted_dates_and_times to handle applica...

### DIFF
--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -6,11 +6,17 @@ module PaperTrail
       extend self # makes all instance methods become module methods as well
 
       def load(string)
-        ::YAML.load string
+        with_unformatted_dates_and_times { ::YAML.load string }
       end
 
       def dump(object)
-        ::YAML.dump object
+        with_unformatted_dates_and_times { ::YAML.dump object }
+      end
+      
+      def with_unformatted_dates_and_times
+        date_format, time_format = Date::DATE_FORMATS[:default], Time::DATE_FORMATS[:default]
+        Date::DATE_FORMATS[:default] = Time::DATE_FORMATS[:default] = nil
+        yield.tap { Date::DATE_FORMATS[:default], Time::DATE_FORMATS[:default] = date_format, time_format }
       end
     end
   end


### PR DESCRIPTION
I was working on an application that had the following set:

    Date::DATE_FORMATS[:default] = "%m/%d/%Y"

Now this is kind of on the YAML module, but I figured it would be more effective to implement a solution here. Basically the issue is that YAML doesn't properly load a dumped object with a formatted date attribute. For example:

```
[1] pry(main)> Date::DATE_FORMATS[:default] = "%m/%d/%Y"
=> "%m/%d/%Y"
[2] pry(main)> YAML.load({date: Date.today}.to_yaml)
=> {:date=>"02/21/2014"}
[3] pry(main)> Date::DATE_FORMATS[:default] = nil
=> nil
[4] pry(main)> YAML.load({date: Date.today}.to_yaml)
=> {:date=>Fri, 21 Feb 2014}
```

So it serializes the date as `"02/21/2014"`, but can only parse dates in the form `"2014-02-01"`.