### PR TITLE
Fallback in user_for_paper_trail to accept current_user returning a string

### DIFF
--- a/lib/paper_trail/frameworks/rails.rb
+++ b/lib/paper_trail/frameworks/rails.rb
@@ -17,7 +17,13 @@ module PaperTrail
       # Override this method in your controller to call a different
       # method, e.g. `current_person`, or anything you like.
       def user_for_paper_trail
-        current_user.try(:id) if defined?(current_user)
+        if defined?(current_user)
+          begin
+            current_user.try(:id)
+          rescue NoMethodError
+            current_user
+          end
+        end
       end
 
       # Returns any information about the controller or request that you


### PR DESCRIPTION
3.0.1 introduced a breaking changes to how current_user works. This is a workaround for backward compatibility.
