### PR TITLE
Make PaperTrail a Rails engine

### DIFF
--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../version_concern', __FILE__)
+require 'paper_trail/version_concern'
 
 module PaperTrail
   class Version < ::ActiveRecord::Base

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -118,7 +118,7 @@ unless PaperTrail.active_record_protected_attributes?
   rescue LoadError; end # will rescue if `ProtectedAttributes` gem is not available
 end
 
-require 'paper_trail/version'
+require 'paper_trail/engine' if defined?(Rails)
 
 # Require frameworks
 require 'paper_trail/frameworks/rails'

--- a/lib/paper_trail/engine.rb
+++ b/lib/paper_trail/engine.rb
@@ -1,0 +1,4 @@
+module PaperTrail
+  class Engine < Rails::Engine
+  end
+end


### PR DESCRIPTION
I've read #216 and you might think it is unnecessary, but it does provide some benefits.

Gems like kamianri assume that every AR model is lazily loaded on Rails in development or auto-loaded in production. With this lazy loading mechanism, we can implement some useful features. For example, kaminari allows the user to change the page method name(by default it is `.page`) to whatever the user wants to call. However, since the `PaperTrail::Version` class is manually `require`d by the gem, it can't take the advantage of this mechanism. As a result, kaminari fails to define the page method with the right name(see: https://github.com/amatsuda/kaminari/pull/262).

It sounds like it is just a kaminari/paper_trail-only issue, but it also could happen to any other gems. To solve that issue, we can make PaperTraila a Rails engine so Rails will automatically load the `PaperTrail::Version` class. Could you think about merging this request?
