### PR TITLE
Fix retrieving :has_one association

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -198,7 +198,7 @@ module PaperTrail
           # but until PaperTrail knows which updates are "together" (e.g. parent and child being
           # updated on the same form), it's impossible to tell when the overall update started;
           # and therefore impossible to know when "just before" was.
-          if (child_as_it_was = child.version_at(send(PaperTrail.timestamp_field) - lookback.seconds))
+          if (child_as_it_was = child.version_at(self.created_at))
             child_as_it_was.attributes.each do |k,v|
               model.send(assoc.name).send :write_attribute, k.to_sym, v rescue nil
             end

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -77,7 +77,6 @@ module PaperTrail
       return nil if object.nil?
 
       without_identity_map do
-        options[:has_one] = 3 if options[:has_one] == true
         options = { :has_one => false }.merge(options)
 
         attrs = self.class.object_col_is_json? ? object : PaperTrail.serializer.load(object)
@@ -118,10 +117,7 @@ module PaperTrail
         end
 
         model.send "#{model.class.version_association_name}=", self
-
-        unless options[:has_one] == false
-          reify_has_ones model, options[:has_one]
-        end
+        reify_has_ones(model) if !!options[:has_one]
 
         model
       end
@@ -187,18 +183,11 @@ module PaperTrail
     # Restore the `model`'s has_one associations as they were when this version was
     # superseded by the next (because that's what the user was looking at when they
     # made the change).
-    #
-    # The `lookback` sets how many seconds before the model's change we go.
-    def reify_has_ones(model, lookback)
+    def reify_has_ones(model)
       model.class.reflect_on_all_associations(:has_one).each do |assoc|
         child = model.send assoc.name
 
         if child.respond_to? :version_at
-          # N.B. we use version of the child as it was `lookback` seconds before the parent was updated.
-          # Ideally we want the version of the child as it was just before the parent was updated...
-          # but until PaperTrail knows which updates are "together" (e.g. parent and child being
-          # updated on the same form), it's impossible to tell when the overall update started;
-          # and therefore impossible to know when "just before" was.
           child_as_it_was = child.version_at(self.created_at)
 
           if !child_as_it_was

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -117,7 +117,7 @@ module PaperTrail
         end
 
         model.send "#{model.class.version_association_name}=", self
-        reify_has_ones(model) if !!options[:has_one]
+        reify_has_ones_for(model, self.created_at) if !!options[:has_one]
 
         model
       end
@@ -183,12 +183,12 @@ module PaperTrail
     # Restore the `model`'s has_one associations as they were when this version was
     # superseded by the next (because that's what the user was looking at when they
     # made the change).
-    def reify_has_ones(model)
+    def reify_has_ones_for(model, version_at_time)
       model.class.reflect_on_all_associations(:has_one).each do |assoc|
         child = model.send assoc.name
 
         if child.respond_to? :version_at
-          child_as_it_was = child.version_at(self.created_at)
+          child_as_it_was = child.version_at(version_at_time)
 
           if !child_as_it_was
             model.send "#{assoc.name}=", nil

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -78,7 +78,7 @@ module PaperTrail
 
       without_identity_map do
         options[:has_one] = 3 if options[:has_one] == true
-        options.reverse_merge! :has_one => false
+        options = { :has_one => false }.merge(options)
 
         attrs = self.class.object_col_is_json? ? object : PaperTrail.serializer.load(object)
 

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -960,7 +960,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       end
 
       context 'when reified' do
-        setup { @widget_0 = @widget.versions.last.reify(:has_one => 1) }
+        setup { @widget_0 = @widget.versions.last.reify(:has_one => true) }
 
         should 'see the associated as it was at the time' do
           assert_nil @widget_0.wotsit
@@ -977,7 +977,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       end
 
       context 'when reified' do
-        setup { @widget_0 = @widget.versions.last.reify(:has_one => 1) }
+        setup { @widget_0 = @widget.versions.last.reify(:has_one => true) }
 
         should 'see the associated as it was at the time' do
           assert_equal 'wotsit_0', @widget_0.wotsit.name
@@ -996,7 +996,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         end
 
         context 'when reified' do
-          setup { @widget_1 = @widget.versions.last.reify(:has_one => 1) }
+          setup { @widget_1 = @widget.versions.last.reify(:has_one => true) }
 
           should 'see the associated as it was at the time' do
             assert_equal 'wotsit_2', @widget_1.wotsit.name
@@ -1021,7 +1021,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         end
 
         context 'when reified' do
-          setup { @widget_2 = @widget.versions.last.reify(:has_one => 1) }
+          setup { @widget_2 = @widget.versions.last.reify(:has_one => true) }
 
           should 'see the associated as it was at the time' do
             assert_nil @widget_2.wotsit


### PR DESCRIPTION
Some weird situation came up when I was working with Paper Trail. I have:
 - created an instance of `Category` and `Post` models
 - added several different categories to DB
 - created new instance of `Post`, associated it with one `Category` and save to the DB
 - edited several times the post without editing the associated category
 - added controller which shows different versions of posts and associated categories
 - tried to show choosen version of the post - here where the problem occurred

In my controller I have tried to retrieve proper version of the post by executing `Version.find(params[:id]).reify(has_one: true)`. Although this command found proper version of `Post` it wasn't be able to find the proper version of `Category`. The problem is here: https://github.com/airblade/paper_trail/blob/ffd7bc233a18f1910588bd0c51a572a235da3c98/lib/paper_trail/version_concern.rb#L201 PaperTrail tried to fetch version of `Category` from max 3 seconds (by default) before chosen version of `Post` was created.

I think the better idea is to drop `lookback` option and fetch proper version of `:has_one` association by using `.version_at`.

I know that I need to update [`README.md`](https://github.com/airblade/paper_trail/blob/ffd7bc233a18f1910588bd0c51a572a235da3c98/README.md) and comments in the code as well, but firstly I want to get some feedback from the maintainers.