### PR TITLE
fix PaperTrail::Rails::Controller.included method

### DIFF
--- a/lib/paper_trail/frameworks/rails.rb
+++ b/lib/paper_trail/frameworks/rails.rb
@@ -3,7 +3,8 @@ module PaperTrail
     module Controller
 
       def self.included(base)
-        if defined?(ActionController) && (base == ActionController::Base || base == ActionController::API)
+        if (defined?(ActionController::Base) && base == ActionController::Base) ||
+            (defined?(ActionController::API) && base == ActionController::API)
           base.before_filter :set_paper_trail_enabled_for_controller
           base.before_filter :set_paper_trail_whodunnit, :set_paper_trail_controller_info
         end


### PR DESCRIPTION
this bombed if the controller wasn't ActionController::Base and the rails-api gem wasn't included.

it seems like there ought to be a better way of doing this in general but this at least prevents the blow up.
