### PR TITLE
fix PaperTrail::Rails::Controller.included method

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -121,7 +121,6 @@ end
 require 'paper_trail/version'
 
 # Require frameworks
-require 'paper_trail/frameworks/rails'
 require 'paper_trail/frameworks/sinatra'
 require 'paper_trail/frameworks/rspec' if defined? RSpec
 require 'paper_trail/frameworks/cucumber' if defined? World
@@ -131,6 +130,7 @@ ActiveSupport.on_load(:active_record) do
 end
 
 if defined?(ActionController)
+  require 'paper_trail/frameworks/rails'
   ActiveSupport.on_load(:action_controller) do
     include PaperTrail::Rails::Controller
   end

--- a/lib/paper_trail/frameworks/rails.rb
+++ b/lib/paper_trail/frameworks/rails.rb
@@ -3,10 +3,8 @@ module PaperTrail
     module Controller
 
       def self.included(base)
-        if defined?(ActionController) && (base == ActionController::Base || base == ActionController::API)
-          base.before_filter :set_paper_trail_enabled_for_controller
-          base.before_filter :set_paper_trail_whodunnit, :set_paper_trail_controller_info
-        end
+        base.before_filter :set_paper_trail_enabled_for_controller
+        base.before_filter :set_paper_trail_whodunnit, :set_paper_trail_controller_info
       end
 
       protected


### PR DESCRIPTION
replaces #351

remove "if" condition and make loading of Rails code conditional.

this bombed if the controller wasn't ActionController::Base and the rails-api gem wasn't included.
