### PR TITLE
Fixes has_many conditions in Rails 4.1

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -61,7 +61,7 @@ module PaperTrail
 
         if ::ActiveRecord::VERSION::MAJOR >= 4 # `has_many` syntax for specifying order uses a lambda in Rails 4
           has_many self.versions_association_name,
-            lambda { |model| order(model.version_class_name.constantize.timestamp_sort_order) },
+            lambda { order(model.timestamp_sort_order) },
             :class_name => self.version_class_name, :as => :item
         else
           has_many self.versions_association_name,


### PR DESCRIPTION
Rails 4.1 passes the association into the scope lambda, not the class. Rather, the associated object's class is available within the context of the lambda as `model`.

Rails 4.0 must have done this differently, or the original code never would have worked.. I haven't had a chance to test my change on 4.0 yet, so while it's confirmed to work on 4.1 it may be breaking 4.0. If that's the case, we could add another version condition here—but I wonder if there's a better way...

Perhaps someone else can help test on 4.0?
