### PR TITLE
added by_version_id to instance methods (similar to version_at(timestamp))

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ widget.originator
 # Returns the widget (not a version) as it looked at the given timestamp.
 widget.version_at(timestamp)
 
+# Returns the widget (not a version) as it looked according to the PaperTrail::Version ID.
+widget.by_version_id(id)
+
 # Returns the widget (not a version) as it was most recently.
 widget.previous_version
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -185,6 +185,12 @@ module PaperTrail
         v ? v.reify(reify_options) : self
       end
 
+      # Returns the object (not a Version) as it was. Searches by the PaperTrail::Version ID
+      def by_version_id(id, reify_options={})
+        v = self.versions.find(id)
+        v ? v.reify(reify_options) : self
+      end
+
       # Returns the objects (not Versions) as they were between the given times.
       def versions_between(start_time, end_time, reify_options={})
         versions = send(self.class.versions_association_name).between(start_time, end_time)


### PR DESCRIPTION
I needed a method where I could save the actual version_id to an associated model of the model with versions and be able to fetch it by the version_id.
