### PR TITLE
Check for RSpec::Core before loading RSpec helpers

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -131,5 +131,5 @@ if defined? Rails
 else
   require 'paper_trail/frameworks/active_record'
 end
-require 'paper_trail/frameworks/rspec' if defined? RSpec
+require 'paper_trail/frameworks/rspec' if defined? RSpec::Core
 require 'paper_trail/frameworks/cucumber' if defined? World


### PR DESCRIPTION
`paper_trail` currently breaks during initialisation whenever `rspec-mocks` is used with another test framework (eg: Minitest).

This is a minor tweak so that `paper_trail` checks that the `RSpec::Core` module is defined before trying to load the RSpec test helpers (`RSpec::Core` will be defined if either the `rspec` gem or it's dependency `rspec-core` is loaded).
