### PR TITLE
Version#reify return new object instance with dup: true options

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ And a `PaperTrail::Version` instance has these methods:
 # Returns the item restored from this version.
 version.reify(options = {})
 
+# Return a new item from this version
+version.reify(dup: true)
+
 # Returns who put the item into the state stored in this version.
 version.originator
 

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -111,6 +111,8 @@ module PaperTrail
     # :has_one     set to `false` to opt out of has_one reification.
     #              set to a float to change the lookback time (check whether your db supports
     #              sub-second datetimes if you want them).
+    # :dup         `false` default behavior
+    #              `true` it always create a new object instance. It is useful for comparing two versions of the same object
     def reify(options = {})
       return nil if object.nil?
 
@@ -133,7 +135,7 @@ module PaperTrail
         # `item_type` will be the base class, not the actual subclass.
         # If `type` is present but empty, the class is the base class.
 
-        if item
+        if item && ! options[:dup]
           model = item
           # Look for attributes that exist in the model and not in this version. These attributes should be set to nil.
           (model.attribute_names - attrs.keys).each { |k| attrs[k] = nil }

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -96,10 +96,29 @@ describe Widget do
               PaperTrail.whodunnit = new_name
               widget.update_attributes(:name => 'Elizabeth')
             end
-            let(:reified_widget) { widget.versions[1].reify }
 
-            it "should return the appropriate originator" do
-              reified_widget.originator.should == orig_name
+            context "reverting a change" do
+              let(:reified_widget) { widget.versions[1].reify }
+
+              it "should return the appropriate originator" do
+                reified_widget.originator.should == orig_name
+              end
+
+              it "should not create a new model instance" do
+                reified_widget.should_not be_new_record
+              end
+            end
+
+            context "creating a new instance" do
+              let(:reified_widget) { widget.versions[1].reify(dup: true) }
+
+              it "should return the appropriate originator" do
+                reified_widget.originator.should == orig_name
+              end
+
+              it "should not create a new model instance" do
+                reified_widget.should be_new_record
+              end
             end
           end
         end


### PR DESCRIPTION
If we want to compare two arbitrary versions, we can use version#reify to retrieve the model from the version, and then creating a diff between the models  (with activerecord-diff for example)

``` ruby
widget = Widget.find(1)
reified_widget1 = widget.versions[0].reify
reified_widget2 = widget.versions[3].reify
changes = reified_widget1.diff(reified_widget2)
```

This strategy fail because reify will not create a new instance. `reified_widget1` and `reified_widget2` are the same object. for this purpose it is possible to call reify with `:dup true` to return a new instance
