### PR TITLE
Documentation Change: add controller enabled to test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,11 +829,14 @@ If you disable PaperTrail in your test environment but want to enable it for spe
 # in test/test_helper.rb
 def with_versioning
   was_enabled = PaperTrail.enabled?
+  was_enabled_for_controller = PaperTrail.enabled_for_controller?
   PaperTrail.enabled = true
+  PaperTrail.enabled_for_controller = true
   begin
     yield
   ensure
     PaperTrail.enabled = was_enabled
+    PaperTrail.enabled_for_controller = was_enabled_for_controller
   end
 end
 ```


### PR DESCRIPTION
Not sure if this is an appropriate change, but it took me quite a while to figure out why one particular model test was failing in the suite but not individually.

If your controller tests load before your model tests the test.rb
config will cause model test versions to not work even after setting
PaperTrail.enabled to true.

See:
https://github.com/bjallen/paper_trail/blob/6de04f199e7c6c885f922c231872d04564fb931c/lib/paper_trail/has_paper_trail.rb#L391
