### PR TITLE
Fix reify method

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -149,7 +149,7 @@ module PaperTrail
 
         # Set all the attributes in this version on the model
         attrs.each do |k, v|
-          if model.respond_to?("#{k}=")
+          if model.has_attribute?(k)
             model[k.to_sym] = v
           else
             logger.warn "Attribute #{k} does not exist on #{item_type} (Version id: #{id})."


### PR DESCRIPTION
When I drop a column in the model, i.e. `address` add replace it with the a association named `address`, I got the following exception:

```
ActiveModel::MissingAttributeError: can't write unknown attribute `address'
  from .../vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.9/lib/active_record/attribute_methods/write.rb:47:in `write_attribute'
  from .../vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.9/lib/active_record/attribute_methods/dirty.rb:70:in `write_attribute'
  from .../vendor/bundle/ruby/2.1.0/gems/enumerize-0.8.0/lib/enumerize/activerecord.rb:51:in `write_attribute'
  from .../vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.9/lib/active_record/attribute_methods.rb:359:in `[]='
  from .../vendor/bundle/ruby/2.1.0/gems/paper_trail-3.0.5/lib/paper_trail/version_concern.rb:152:in `block (2 levels) in reify'
  from .../vendor/bundle/ruby/2.1.0/gems/paper_trail-3.0.5/lib/paper_trail/version_concern.rb:150:in `each'
  from .../vendor/bundle/ruby/2.1.0/gems/paper_trail-3.0.5/lib/paper_trail/version_concern.rb:150:in `block in reify'
  from .../vendor/bundle/ruby/2.1.0/gems/paper_trail-3.0.5/lib/paper_trail/version_concern.rb:225:in `call'
  from .../vendor/bundle/ruby/2.1.0/gems/paper_trail-3.0.5/lib/paper_trail/version_concern.rb:225:in `without_identity_map'
  from .../vendor/bundle/ruby/2.1.0/gems/paper_trail-3.0.5/lib/paper_trail/version_concern.rb:117:in `reify'
```

It's because the `reify` method use `model.respond_to?("#{k}=")` rather than `model.has_attribute?(k)`, so it could cause exception if I define a method named `address=` as well.

This pull request is to fix this error
