### PR TITLE
store attribute metadata as it exists at creation, instead of nil

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -403,8 +403,9 @@ module PaperTrail
             if v.respond_to?(:call)
               v.call(self)
             elsif v.is_a?(Symbol) && respond_to?(v)
-              # if it is an attribute that is changing, be sure to grab the current version
-              if has_attribute?(v) && send("#{v}_changed?".to_sym)
+              # if it is an attribute that is changing in an existing object, 
+              # be sure to grab the current version
+              if has_attribute?(v) && send("#{v}_changed?".to_sym) && data[:event] != 'create'
                 send("#{v}_was".to_sym)
               else
                 send(v)

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -800,8 +800,8 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         assert_equal @article.action_data_provider_method, @article.versions.last.action
       end
 
-      should 'store dynamic meta data based on an attribute of the item prior to creation' do
-        assert_equal nil, @article.versions.last.title
+      should 'store dynamic meta data based on an attribute of the item at creation' do
+        assert_equal @initial_title, @article.versions.last.title
       end
 
 


### PR DESCRIPTION
When the initial paper trail version is created any attribute metadata will be nil instead of the values that exist, because #{attribute}_was will always return nil for new models. This looks like an explicit decision, given there is a test, but I don't understand the logic behind it. 
For background, in my case I'm building a multi-tenant application and I'm adding the tenant id attribute to my paper trail version metadata. It's important for us to be able to query the version history restricted by tenant, and with the current behavior it's impossible to match create events with a tenant without reifying the actual objects.
Any other use case for storing attribute metadata I can think of also would benefit from storing the metadata that exists at create, rather than storing nil, but maybe I'm missing something?