### PR TITLE
Versioning a model that has a polymorphic belongs_to association

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -372,7 +372,7 @@ module PaperTrail
       # saves associations if the join table for `VersionAssociation` exists
       def save_associations(version)
         return unless PaperTrail::VersionAssociation.table_exists?
-        self.class.reflect_on_all_associations(:belongs_to).each do |assoc|
+        self.class.reflect_on_all_associations(:belongs_to).reject(&:polymorphic?).each do |assoc|
           if assoc.klass.paper_trail_enabled_for_model?
             PaperTrail::VersionAssociation.create(
               :version_id => version.id,

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -372,7 +372,7 @@ module PaperTrail
       # saves associations if the join table for `VersionAssociation` exists
       def save_associations(version)
         return unless PaperTrail::VersionAssociation.table_exists?
-        self.class.reflect_on_all_associations(:belongs_to).reject(&:polymorphic?).each do |assoc|
+        self.class.reflect_on_all_associations(:belongs_to).reject { |it| it.options[:polymorphic] }.each do |assoc|
           if assoc.klass.paper_trail_enabled_for_model?
             PaperTrail::VersionAssociation.create(
               :version_id => version.id,

--- a/test/dummy/app/models/book.rb
+++ b/test/dummy/app/models/book.rb
@@ -5,5 +5,7 @@ class Book < ActiveRecord::Base
   has_many :editorships, :dependent => :destroy
   has_many :editors, :through => :editorships
 
+  has_many :reviews, :as => :reviewable
+
   has_paper_trail
 end

--- a/test/dummy/app/models/review.rb
+++ b/test/dummy/app/models/review.rb
@@ -1,0 +1,5 @@
+class Review < ActiveRecord::Base
+  belongs_to :reviewable, polymorphic: true
+
+  has_paper_trail
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -101,6 +101,12 @@ class SetUpTestTables < ActiveRecord::Migration
       t.string :name
     end
 
+    create_table :reviews, :force => true do |t|
+      t.integer :reviewable_id
+      t.string :reviewable_type
+      t.integer :rating
+    end
+
     create_table :songs, :force => true do |t|
       t.integer :length
     end
@@ -160,6 +166,7 @@ class SetUpTestTables < ActiveRecord::Migration
     drop_table :animals
     drop_table :posts
     drop_table :songs
+    drop_table :reviews
     drop_table :editors
     drop_table :editorships
     drop_table :people

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -106,6 +106,12 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "content"
   end
 
+  create_table "reviews", force: true do |t|
+    t.integer "reviewable_id"
+    t.string  "reviewable_type"
+    t.integer "rating"
+  end
+
   create_table "songs", force: true do |t|
     t.integer "length"
   end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1838,4 +1838,25 @@ class HasPaperTrailModelTransactionalTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context 'A model with a polymorphic belongs_to association' do
+    setup do
+      @book = Book.new :title => 'book_0'
+      @review = Review.create :reviewable => @book, :rating => 5
+      @review.update_attributes! :rating => 3
+    end
+
+    context 'when reified' do
+      setup { @review_0 = @review.versions.last.reify }
+
+      should 'be available in its previous version' do
+        assert_equal @review_0.id, @review.id
+        assert_equal @review_0.rating, 5
+      end
+
+      should 'ignore versioning the association' do
+        assert_equal @review.versions.last.version_associations.size, 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
New association versioning feature is broken for polymorphic belongs_to associations as reflection has no way to point to the dynamically set [associated model class](https://github.com/kaapa/paper_trail/compare/polymorphic_belongs_to_association?expand=1#diff-7fc294d950a7311cf6ad815a91f90ac2L376).

These commits add a failing test case and a "fix" by disabling the feature for polymorphic associations.