### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The Rails 2.3 code is on the [`rails2`](https://github.com/airblade/paper_trail/
 
 1. Add PaperTrail to your `Gemfile`.
 
-    `gem 'paper_trail', '~> 3.0.6'`
+    `gem 'paper_trail', '~> 4.0.0.beta'`
 
 2. Generate a migration which will add a `versions` table to your database.
 


### PR DESCRIPTION
There is a typo in the master branch readme.  3.0.6 will not get the features documented in the page.  This is very confusing.