### PR TITLE
Avoid looking up item when reifying with dup: true

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -165,7 +165,7 @@ module PaperTrail
         # `item_type` will be the base class, not the actual subclass.
         # If `type` is present but empty, the class is the base class.
 
-        if item && options[:dup] != true
+        if options[:dup] != true && item
           model = item
           # Look for attributes that exist in the model and not in this version. These attributes should be set to nil.
           (model.attribute_names - attrs.keys).each { |k| attrs[k] = nil }


### PR DESCRIPTION
When `dup: true` is set on reify we don't need to look up the item. This helps in avoiding unnecessary lookup when showing lists of reified versions