### PR TITLE
Deal with `on: []`

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -70,14 +70,15 @@ module PaperTrail
             :order      => self.paper_trail_version_class.timestamp_sort_order
         end
 
-        options_on = Array(options[:on]) unless options[:on].nil? # so that a single symbol can be passed in without wrapping it in an `Array`
-        after_create  :record_create, :if => :save_version? if options_on.nil? || options_on.include?(:create)
-        if options_on.nil? || options_on.include?(:update)
+        options[:on] ||= [:create, :update, :destroy]
+        options_on = Array(options[:on]) # so that a single symbol can be passed in without wrapping it in an `Array`
+        after_create  :record_create, :if => :save_version? if options_on.include?(:create)
+        if options_on.include?(:update)
           before_save   :reset_timestamp_attrs_for_update_if_needed!, :on => :update
           after_update  :record_update, :if => :save_version?
           after_update  :clear_version_instance!
         end
-        after_destroy :record_destroy, :if => :save_version? if options_on.nil? || options_on.include?(:destroy)
+        after_destroy :record_destroy, :if => :save_version? if options_on.include?(:destroy)
 
         # Reset the transaction id when the transaction is closed
         after_commit :reset_transaction_id

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -70,14 +70,14 @@ module PaperTrail
             :order      => self.paper_trail_version_class.timestamp_sort_order
         end
 
-        options_on = Array(options[:on]) # so that a single symbol can be passed in without wrapping it in an `Array`
-        after_create  :record_create, :if => :save_version? if options_on.empty? || options_on.include?(:create)
-        if options_on.empty? || options_on.include?(:update)
+        options_on = Array(options[:on]) unless options[:on].nil? # so that a single symbol can be passed in without wrapping it in an `Array`
+        after_create  :record_create, :if => :save_version? if options_on.nil? || options_on.include?(:create)
+        if options_on.nil? || options_on.include?(:update)
           before_save   :reset_timestamp_attrs_for_update_if_needed!, :on => :update
           after_update  :record_update, :if => :save_version?
           after_update  :clear_version_instance!
         end
-        after_destroy :record_destroy, :if => :save_version? if options_on.empty? || options_on.include?(:destroy)
+        after_destroy :record_destroy, :if => :save_version? if options_on.nil? || options_on.include?(:destroy)
 
         # Reset the transaction id when the transaction is closed
         after_commit :reset_transaction_id

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -270,6 +270,7 @@ module PaperTrail
 
         attributes.each { |column| write_attribute(column, current_time) }
         save!
+        record_update(true) if self.class.paper_trail_options[:on] == []
       end
 
       private
@@ -300,8 +301,8 @@ module PaperTrail
         end
       end
 
-      def record_update
-        if paper_trail_switched_on? && changed_notably?
+      def record_update(force = nil)
+        if paper_trail_switched_on? && (force || changed_notably?)
           object_attrs = object_attrs_for_paper_trail(attributes_before_change)
           data = {
             :event     => paper_trail_event || 'update',

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1213,10 +1213,19 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         END
         @fluxor = Fluxor.create
         @fluxor.update_attributes :name => 'blah'
+      end
+
+      teardown do
         @fluxor.destroy
       end
+
       should 'not have any versions' do
         assert_equal 0, @fluxor.versions.length
+      end
+
+      should 'still respond to touch_with_version' do
+        @fluxor.touch_with_version
+        assert_equal 1, @fluxor.versions.length
       end
     end
     context 'allows a symbol to be passed' do

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1203,6 +1203,22 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         assert_equal 'destroy', @fluxor.versions.last.event
       end
     end
+    context 'on []' do
+      setup do
+        Fluxor.reset_callbacks :create
+        Fluxor.reset_callbacks :update
+        Fluxor.reset_callbacks :destroy
+        Fluxor.instance_eval <<-END
+          has_paper_trail :on => []
+        END
+        @fluxor = Fluxor.create
+        @fluxor.update_attributes :name => 'blah'
+        @fluxor.destroy
+      end
+      should 'not have any versions' do
+        assert_equal 0, @fluxor.versions.length
+      end
+    end
     context 'allows a symbol to be passed' do
       setup do
         Fluxor.reset_callbacks :create


### PR DESCRIPTION
See #481 for more discussion. This pull request enables `on: []` to disable all automatic versioning, yet still forces `touch_with_version` to write a version.