### PR TITLE
Fixing bug with `PaperTrail::VersionAssociation.table_exists?` check

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -9,7 +9,7 @@ module PaperTrail
 
       # Need to inspect inside of a Proc so that tests pass even when DB is not initialized
       # such as when we run on Travis (there won't be a db in `test/dummy/db/`)
-      if lambda { PaperTrail::VersionAssociation.table_exists? }
+      if (lambda { PaperTrail::VersionAssociation.table_exists? }).call
         has_many :version_associations, :dependent => :destroy
       end
 


### PR DESCRIPTION
Not a real pull request. Wanted to start a dialogue about the issue.
The lambda always returns true to the best of my knowledge because it creates a proc and a proc is not false. What's the Original Author's(or should I say, Original Fixer) intent behind the change. Is there another way to fix it?