### PR TITLE
if belongs_to: returns a nil object it crashes

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -382,7 +382,8 @@ module PaperTrail
           }
 
           if assoc.options[:polymorphic]
-            if (associated_record = send(assoc.name)).class.paper_trail_enabled_for_model?
+            associated_record = send(assoc.name)
+            if associated_record && associated_record.class.paper_trail_enabled_for_model?
               assoc_version_args.merge!(:foreign_key_id => associated_record.id)
             end
           elsif assoc.klass.paper_trail_enabled_for_model?

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -72,8 +72,8 @@ class SetUpTestTables < ActiveRecord::Migration
     end
 
     create_table :whatchamajiggers, :force => true do |t|
-      t.string  :owner_type, :null => false
-      t.integer :owner_id, :null => false
+      t.string  :owner_type
+      t.integer :owner_id
       t.string  :name
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -146,8 +146,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
 
   create_table "whatchamajiggers", force: true do |t|
-    t.string  "owner_type", null: false
-    t.integer "owner_id",   null: false
+    t.string  "owner_type"
+    t.integer "owner_id"
     t.string  "name"
   end
 

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -348,6 +348,16 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
           end
         end
 
+        context 'polymorphic objects by themselves' do
+          setup do
+            @widget = Whatchamajigger.new :name => 'f-zero'
+          end
+
+          should 'not fail with a nil pointer on the polymorphic association' do
+            @widget.save!
+          end
+        end
+
         context 'and then destroyed' do
           setup do
             @fluxor = @widget.fluxors.create :name => 'flux'


### PR DESCRIPTION
turns out that if you have a model with belongs_to, a polymorphic association, and nil, bad things happen.

this PR fixes that.