### PR TITLE
Add flag to skip saving object_changes when column exists

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -10,26 +10,28 @@ module PaperTrail
       # the model is available in the `versions` association.
       #
       # Options:
-      # :on           the events to track (optional; defaults to all of them).  Set to an array of
-      #               `:create`, `:update`, `:destroy` as desired.
-      # :class_name   the name of a custom Version class.  This class should inherit from `PaperTrail::Version`.
-      # :ignore       an array of attributes for which a new `Version` will not be created if only they change.
-      #               it can also aceept a Hash as an argument where the key is the attribute to ignore (a `String` or `Symbol`),
-      #               which will only be ignored if the value is a `Proc` which returns truthily.
-      # :if, :unless  Procs that allow to specify conditions when to save versions for an object
-      # :only         inverse of `ignore` - a new `Version` will be created only for these attributes if supplied
-      #               it can also aceept a Hash as an argument where the key is the attribute to track (a `String` or `Symbol`),
-      #               which will only be counted if the value is a `Proc` which returns truthily.
-      # :skip         fields to ignore completely.  As with `ignore`, updates to these fields will not create
-      #               a new `Version`.  In addition, these fields will not be included in the serialized versions
-      #               of the object whenever a new `Version` is created.
-      # :meta         a hash of extra data to store.  You must add a column to the `versions` table for each key.
-      #               Values are objects or procs (which are called with `self`, i.e. the model with the paper
-      #               trail).  See `PaperTrail::Controller.info_for_paper_trail` for how to store data from
-      #               the controller.
-      # :versions     the name to use for the versions association.  Default is `:versions`.
-      # :version      the name to use for the method which returns the version the instance was reified from.
-      #               Default is `:version`.
+      # :on            the events to track (optional; defaults to all of them).  Set to an array of
+      #                `:create`, `:update`, `:destroy` as desired.
+      # :class_name    the name of a custom Version class.  This class should inherit from `PaperTrail::Version`.
+      # :ignore        an array of attributes for which a new `Version` will not be created if only they change.
+      #                it can also aceept a Hash as an argument where the key is the attribute to ignore (a `String` or `Symbol`),
+      #                which will only be ignored if the value is a `Proc` which returns truthily.
+      # :if, :unless   Procs that allow to specify conditions when to save versions for an object
+      # :only          inverse of `ignore` - a new `Version` will be created only for these attributes if supplied
+      #                it can also aceept a Hash as an argument where the key is the attribute to track (a `String` or `Symbol`),
+      #                which will only be counted if the value is a `Proc` which returns truthily.
+      # :skip          fields to ignore completely.  As with `ignore`, updates to these fields will not create
+      #                a new `Version`.  In addition, these fields will not be included in the serialized versions
+      #                of the object whenever a new `Version` is created.
+      # :meta          a hash of extra data to store.  You must add a column to the `versions` table for each key.
+      #                Values are objects or procs (which are called with `self`, i.e. the model with the paper
+      #                trail).  See `PaperTrail::Controller.info_for_paper_trail` for how to store data from
+      #                the controller.
+      # :versions      the name to use for the versions association.  Default is `:versions`.
+      # :version       the name to use for the method which returns the version the instance was reified from.
+      #                Default is `:version`.
+      # :save_changes  whether or not to save changes to the object_changes column if it exists. Default is true
+      #
       def has_paper_trail(options = {})
         # Lazily include the instance methods so we don't clutter up
         # any more ActiveRecord models than we have to.
@@ -53,6 +55,7 @@ module PaperTrail
         end
 
         paper_trail_options[:meta] ||= {}
+        paper_trail_options[:save_changes] = true if paper_trail_options[:save_changes].nil?
 
         class_attribute :versions_association_name
         self.versions_association_name = options[:versions] || :versions
@@ -269,7 +272,7 @@ module PaperTrail
         current_time = current_time_from_proper_timezone
 
         attributes.each { |column| write_attribute(column, current_time) }
-        # ensure a version is written even if the 
+        # ensure a version is written even if the
         record_update(true) if paper_trail_options[:on] == []
         save!
       end
@@ -289,7 +292,7 @@ module PaperTrail
           if respond_to?(:created_at)
             data[PaperTrail.timestamp_field] = created_at
           end
-          if changed_notably? and self.class.paper_trail_version_class.column_names.include?('object_changes')
+          if paper_trail_options[:save_changes] && changed_notably? && self.class.paper_trail_version_class.column_names.include?('object_changes')
             data[:object_changes] = self.class.paper_trail_version_class.object_changes_col_is_json? ? changes_for_paper_trail :
               PaperTrail.serializer.dump(changes_for_paper_trail)
           end
@@ -313,7 +316,7 @@ module PaperTrail
           if respond_to?(:updated_at)
             data[PaperTrail.timestamp_field] = updated_at
           end
-          if self.class.paper_trail_version_class.column_names.include?('object_changes')
+          if paper_trail_options[:save_changes] && self.class.paper_trail_version_class.column_names.include?('object_changes')
             data[:object_changes] = self.class.paper_trail_version_class.object_changes_col_is_json? ? changes_for_paper_trail :
               PaperTrail.serializer.dump(changes_for_paper_trail)
           end

--- a/spec/models/thing_spec.rb
+++ b/spec/models/thing_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Thing, :type => :model do
+  it { is_expected.to be_versioned }
+
+  describe "should not store object_changes", :versioning => true do
+    let(:thing) { Thing.create(name: "pencil") }
+
+    it { expect(thing.versions.last.object_changes).to be_nil }
+  end
+end

--- a/spec/models/thing_spec.rb
+++ b/spec/models/thing_spec.rb
@@ -4,7 +4,7 @@ describe Thing, :type => :model do
   it { is_expected.to be_versioned }
 
   describe "should not store object_changes", :versioning => true do
-    let(:thing) { Thing.create(name: "pencil") }
+    let(:thing) { Thing.create(:name =>"pencil") }
 
     it { expect(thing.versions.last.object_changes).to be_nil }
   end

--- a/test/dummy/app/models/thing.rb
+++ b/test/dummy/app/models/thing.rb
@@ -1,0 +1,3 @@
+class Thing < ActiveRecord::Base
+  has_paper_trail save_changes: false
+end

--- a/test/dummy/app/models/thing.rb
+++ b/test/dummy/app/models/thing.rb
@@ -1,3 +1,3 @@
 class Thing < ActiveRecord::Base
-  has_paper_trail save_changes: false
+  has_paper_trail :save_changes => false
 end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -134,6 +134,10 @@ class SetUpTestTables < ActiveRecord::Migration
       t.integer   :version
     end
 
+    create_table :things, :force => true do |t|
+      t.string    :name
+    end
+
     create_table :translations, :force => true do |t|
       t.string    :headline
       t.string    :content

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -109,6 +109,10 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.integer "length"
   end
 
+  create_table "things", force: true do |t|
+    t.string "name"
+  end
+
   create_table "translations", force: true do |t|
     t.string "headline"
     t.string "content"


### PR DESCRIPTION
For certain models especially with large TEXT columns I don't want to store object_changes but still need object_changes stored on other models.  I set the key name to :save_changes but can rename this to whatever you think is best.