### PR TITLE
Fixed: the redefined methods problem

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -185,7 +185,7 @@ module PaperTrail
         # Set all the attributes in this version on the model
         attrs.each do |k, v|
           if model.has_attribute?(k)
-            model[k.to_sym] = v
+            model.send "#{k}=", v
           else
             logger.warn "Attribute #{k} does not exist on #{item_type} (Version id: #{id})."
           end


### PR DESCRIPTION
I have tried to fix problem with redefined attribute methods in a model.
Now, I get problem if I redefine an attribute getter and setter. For example:

```
def price=(value)
  write_attribute(:price, value / 60)
end

def price
  read_attribute(:price) * 60 
end
```

Version model use new getter (`price`) for store a value, but when it restore the value, version don't use my new setter.