### PR TITLE
Fixes `touch_with_version` re: the `:on` option

### DIFF
--- a/spec/models/not_on_update_spec.rb
+++ b/spec/models/not_on_update_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe NotOnUpdate, :type => :model do
+  describe "#touch_with_version", :versioning => true do
+    let!(:record) { described_class.create! }
+
+    it "should create a version, regardless" do
+      expect { record.touch_with_version }.to change {
+        PaperTrail::Version.count
+      }.by(+1)
+    end
+
+    it "increments the `:updated_at` timestamp" do
+      before = record.updated_at
+      record.touch_with_version
+      expect(record.updated_at).to be > before
+    end
+  end
+end

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -252,13 +252,13 @@ describe Widget, :type => :model do
       describe '#touch_with_version' do
         it { is_expected.to respond_to(:touch_with_version) }
 
-        it "should generate a version" do
+        it "creates a version" do
           count = widget.versions.size
           widget.touch_with_version
           expect(widget.versions.size).to eq(count + 1)
         end
 
-        it "should increment the `:updated_at` timestamp" do
+        it "increments the `:updated_at` timestamp" do
           time_was = widget.updated_at
           widget.touch_with_version
           expect(widget.updated_at).to be > time_was

--- a/test/dummy/app/models/not_on_update.rb
+++ b/test/dummy/app/models/not_on_update.rb
@@ -1,0 +1,4 @@
+# This model does not record versions when updated.
+class NotOnUpdate < ActiveRecord::Base
+  has_paper_trail :on => [:create, :destroy]
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -73,6 +73,10 @@ class SetUpTestTables < ActiveRecord::Migration
       add_index :json_versions, [:item_type, :item_id]
     end
 
+    create_table :not_on_updates, :force => true do |t|
+      t.timestamps :null => true
+    end
+
     create_table :bananas, :force => true do |t|
       t.timestamps :null => true
     end
@@ -205,6 +209,7 @@ class SetUpTestTables < ActiveRecord::Migration
 
   def self.down
     drop_table :animals
+    drop_table :not_on_updates
     drop_table :posts
     drop_table :songs
     drop_table :editors


### PR DESCRIPTION
Fixes a bug where `touch_with_version` fails to create a version.

##### Table: Is a version created?

The :on option | Without PR | With PR
-------------------- | ---------------- | -----------------
`nil` | yes | yes
`[]` | yes | yes
`[:update]` | yes | yes
`[:create]` | **no** | **yes**