### PR TITLE
Remove deprecated: paper_trail_on, paper_trail_off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ candidates.
   https://github.com/airblade/paper_trail/pull/492.
 - If you depend on the `RSpec` or `Cucumber` helpers, you must
   [require them in your test helper](https://github.com/airblade/paper_trail#testing).
+- [#577](https://github.com/airblade/paper_trail/pull/577) - Removed deprecated
+  methods `paper_trail_on` and `paper_trail_off`. Use `paper_trail_on!` and
+  `paper_trail_off!` instead.
 - [#458](https://github.com/airblade/paper_trail/pull/458) - Version metadata
   (the `:meta` option) from AR attributes for `create` events will now save the
   current value instead of `nil`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ candidates.
   https://github.com/airblade/paper_trail/pull/492.
 - If you depend on the `RSpec` or `Cucumber` helpers, you must
   [require them in your test helper](https://github.com/airblade/paper_trail#testing).
-- [#577](https://github.com/airblade/paper_trail/pull/577) - Removed deprecated
-  methods `paper_trail_on` and `paper_trail_off`. Use `paper_trail_on!` and
-  `paper_trail_off!` instead.
 - [#458](https://github.com/airblade/paper_trail/pull/458) - Version metadata
   (the `:meta` option) from AR attributes for `create` events will now save the
   current value instead of `nil`.
@@ -32,6 +29,12 @@ candidates.
 - `3da1f104` - `PaperTrail.config` and `PaperTrail.configure` are now
   identical: both return the `PaperTrail::Config` instance and also
   yield it if a block is provided.
+  
+### Removed
+
+- [#577](https://github.com/airblade/paper_trail/pull/577) - Removed deprecated
+  methods `paper_trail_on` and `paper_trail_off`. Use `paper_trail_on!` and
+  `paper_trail_off!` instead.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ candidates.
   
 ### Removed
 
-- [#577](https://github.com/airblade/paper_trail/pull/577) - Removed deprecated
+- [#566](https://github.com/airblade/paper_trail/pull/566) - Removed deprecated
   methods `paper_trail_on` and `paper_trail_off`. Use `paper_trail_on!` and
   `paper_trail_off!` instead.
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -96,19 +96,9 @@ module PaperTrail
         PaperTrail.enabled_for_model(self, false)
       end
 
-      def paper_trail_off
-        warn "DEPRECATED: use `paper_trail_off!` instead of `paper_trail_off`. Support for `paper_trail_off` will be removed in PaperTrail 4.0"
-        self.paper_trail_off!
-      end
-
       # Switches PaperTrail on for this class.
       def paper_trail_on!
         PaperTrail.enabled_for_model(self, true)
-      end
-
-      def paper_trail_on
-        warn "DEPRECATED: use `paper_trail_on!` instead of `paper_trail_on`. Support for `paper_trail_on` will be removed in PaperTrail 4.0"
-        self.paper_trail_on!
       end
 
       def paper_trail_enabled_for_model?

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -282,21 +282,6 @@ describe Widget, :type => :model do
         end
       end
 
-      describe '#paper_trail_off' do
-        it { is_expected.to respond_to(:paper_trail_off) }
-
-        it 'should set the invoke `paper_trail_off!`' do
-          is_expected.to receive(:warn)
-          is_expected.to receive(:paper_trail_off!)
-          subject.paper_trail_off
-        end
-
-        it 'should display a deprecation warning' do
-          is_expected.to receive(:warn).with("DEPRECATED: use `paper_trail_on!` instead of `paper_trail_on`. Support for `paper_trail_on` will be removed in PaperTrail 4.0")
-          subject.paper_trail_on
-        end
-      end
-
       describe '#paper_trail_on!' do
         before { subject.paper_trail_off! }
 
@@ -306,23 +291,6 @@ describe Widget, :type => :model do
           expect(subject.paper_trail_enabled_for_model?).to be false
           subject.paper_trail_on!
           expect(subject.paper_trail_enabled_for_model?).to be true
-        end
-      end
-
-      describe '#paper_trail_on' do
-        before { subject.paper_trail_off! }
-
-        it { is_expected.to respond_to(:paper_trail_on) }
-
-        it 'should set the invoke `paper_trail_on!`' do
-          is_expected.to receive(:warn)
-          is_expected.to receive(:paper_trail_on!)
-          subject.paper_trail_on
-        end
-
-        it 'should display a deprecation warning' do
-          is_expected.to receive(:warn).with("DEPRECATED: use `paper_trail_on!` instead of `paper_trail_on`. Support for `paper_trail_on` will be removed in PaperTrail 4.0")
-          subject.paper_trail_on
         end
       end
     end


### PR DESCRIPTION
I noticed the changelog for version 3.0.1 says these were to be removed in 4.0. :scissors: :scissors: 