### PR TITLE
Respect `:skip` re: timestamp-only updates

### DIFF
--- a/spec/models/gadget_spec.rb
+++ b/spec/models/gadget_spec.rb
@@ -45,7 +45,7 @@ describe Gadget, :type => :model do
                 expect(subject.send(:changed_notably?)).to be true
               end
 
-              it "should not acknowledge ignored attrs and timestamps only" do
+              it "should not acknowledge ignored attr (brand)" do
                 subject.brand = 'Acme'
                 expect(subject.send(:changed_notably?)).to be false
               end

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Skipper, :type => :model do
+  describe "#update_attributes!", :versioning => true do
+    context "updating a skipped attribute" do
+      let(:t1) { Time.zone.local(2015, 7, 15, 20, 34, 0) }
+      let(:t2) { Time.zone.local(2015, 7, 15, 20, 34, 30) }
+
+      it "should not create a version" do
+        skipper = Skipper.create!(:another_timestamp => t1)
+        expect {
+          skipper.update_attributes!(:another_timestamp => t2)
+        }.to_not change { skipper.versions.length }
+      end
+    end
+  end
+end

--- a/test/dummy/app/models/skipper.rb
+++ b/test/dummy/app/models/skipper.rb
@@ -1,0 +1,6 @@
+class Skipper < ActiveRecord::Base
+  has_paper_trail(
+    :ignore => [:created_at],
+    :skip => [:another_timestamp]
+  )
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -1,5 +1,10 @@
 class SetUpTestTables < ActiveRecord::Migration
   def self.up
+    create_table :skippers, :force => true do |t|
+      t.datetime :another_timestamp
+      t.timestamps :null => true
+    end
+
     create_table :widgets, :force => true do |t|
       t.string    :name
       t.text      :a_text
@@ -209,6 +214,7 @@ class SetUpTestTables < ActiveRecord::Migration
 
   def self.down
     drop_table :animals
+    drop_table :skippers
     drop_table :not_on_updates
     drop_table :posts
     drop_table :songs


### PR DESCRIPTION
When attributes are ignored, either by `:ignore` or by `:skip`,
then during updates, timestamp attributes like `updated_at` should
not be considered notable changes.

[Fixes #569]