### PR TITLE
Relax version constraint on request_store

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', ['>= 3.0', '< 6.0']
   s.add_dependency 'activesupport', ['>= 3.0', '< 6.0']
-  s.add_dependency 'request_store', '~> 1.1.0'
+  s.add_dependency 'request_store', '~> 1.1'
 
   s.add_development_dependency 'rake', '~> 10.1.1'
   s.add_development_dependency 'shoulda', '~> 3.5'


### PR DESCRIPTION
.. to allow `request_store` 1.2.

AFAICT they don't have a changelog, so we have to review commits:

https://github.com/steveklabnik/request_store/commits/master

The only new feature appears to be:

https://github.com/steveklabnik/request_store/pull/37