### PR TITLE
Organize 4.0.0 change list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ candidates.
   https://github.com/airblade/paper_trail/pull/492.
 - If you depend on the `RSpec` or `Cucumber` helpers, you must
   [require them in your test helper](https://github.com/airblade/paper_trail#testing).
+- [#566](https://github.com/airblade/paper_trail/pull/566) - Removed deprecated
+  methods `paper_trail_on` and `paper_trail_off`. Use `paper_trail_on!` and
+  `paper_trail_off!` instead.
 - [#458](https://github.com/airblade/paper_trail/pull/458) - Version metadata
   (the `:meta` option) from AR attributes for `create` events will now save the
   current value instead of `nil`.
@@ -44,12 +47,6 @@ candidates.
 - `3da1f104` - `PaperTrail.config` and `PaperTrail.configure` are now
   identical: both return the `PaperTrail::Config` instance and also
   yield it if a block is provided.
-  
-### Removed
-
-- [#566](https://github.com/airblade/paper_trail/pull/566) - Removed deprecated
-  methods `paper_trail_on` and `paper_trail_off`. Use `paper_trail_on!` and
-  `paper_trail_off!` instead.
 
 ### Added
 


### PR DESCRIPTION
Keeping all changes in a single list means users only have to look
in one place when they upgrade.

In this case, the "Removed" item was really obvious, but in general
a single list is a good practice, I think.

A single list is also recommended by http://keepachangelog.com/
which I'm a big fan of.

[ci skip]