### PR TITLE
Prevent global variable pollution

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -85,6 +85,14 @@ module PaperTrail
     paper_trail_store[:whodunnit]
   end
 
+  # whodunnit for a given block of code
+  def self.with_whodunnit(value)
+    old, self.whodunnit = whodunnit, value
+    yield
+  ensure
+    self.whodunnit = old
+  end
+
   # Sets any information from the controller that you want PaperTrail to
   # store.  By default this is set automatically by a before filter.
   def self.controller_info=(value)

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -107,6 +107,14 @@ module PaperTrail
     paper_trail_store[:controller_info]
   end
 
+  # controller_info for a given block of code
+  def self.with_controller_info(info)
+    old, self.controller_info = controller_info, value
+    yield
+  ensure
+    self.controller_info = old
+  end
+
   # Getter and Setter for PaperTrail Serializer
   def self.serializer=(value)
     PaperTrail.config.serializer = value

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -24,6 +24,14 @@ module PaperTrail
     !!PaperTrail.config.enabled
   end
 
+  # Disable or enable for a given block of code
+  def self.with_enabled(value)
+    old, self.enabled = enabled?, value
+    yield
+  ensure
+    self.enabled = old
+  end
+
   # ActiveRecord 5 drops support for serialized attributes; for previous
   # versions of ActiveRecord it is supported, we have a config option
   # to enable it within PaperTrail.

--- a/lib/paper_trail/frameworks/rails/controller.rb
+++ b/lib/paper_trail/frameworks/rails/controller.rb
@@ -4,7 +4,7 @@ module PaperTrail
 
       def self.included(base)
         base.before_filter :set_paper_trail_enabled_for_controller
-        base.before_filter :set_paper_trail_whodunnit, :set_paper_trail_controller_info
+        base.around_filter :set_paper_trail_whodunnit, :set_paper_trail_controller_info
       end
 
       protected
@@ -61,14 +61,22 @@ module PaperTrail
       end
 
       # Tells PaperTrail who is responsible for any changes that occur.
-      def set_paper_trail_whodunnit
-        ::PaperTrail.whodunnit = user_for_paper_trail if ::PaperTrail.enabled_for_controller?
+      def set_paper_trail_whodunnit(&block)
+        if ::PaperTrail.enabled_for_controller?
+          ::PaperTrail.with_whodunnit(user_for_paper_trail, &block)
+        else
+          yield
+        end
       end
 
       # Tells PaperTrail any information from the controller you want to store
       # alongside any changes that occur.
-      def set_paper_trail_controller_info
-        ::PaperTrail.controller_info = info_for_paper_trail if ::PaperTrail.enabled_for_controller?
+      def set_paper_trail_controller_info(&block)
+        if ::PaperTrail.enabled_for_controller?
+          ::PaperTrail.with_controller_info(info_for_paper_trail, &block)
+        else
+          yield
+        end
       end
 
     end

--- a/test/paper_trail_test.rb
+++ b/test/paper_trail_test.rb
@@ -24,6 +24,14 @@ class PaperTrailTest < ActiveSupport::TestCase
     assert PaperTrail.enabled?
   end
 
+  test 'with_whodunnit' do
+    refute PaperTrail.whodunnit
+    PaperTrail.with_whodunnit("Pete") do
+      assert_equal "Pete", PaperTrail.whodunnit
+    end
+    refute PaperTrail.whodunnit
+  end
+
   test 'create with plain model class' do
     widget = Widget.create
     assert_equal 1, widget.versions.length

--- a/test/paper_trail_test.rb
+++ b/test/paper_trail_test.rb
@@ -8,11 +8,19 @@ class PaperTrailTest < ActiveSupport::TestCase
   test 'Version Number' do
     assert PaperTrail.const_defined?(:VERSION)
   end
-  
+
   test 'enabled is thread-safe' do
     Thread.new do
       PaperTrail.enabled = false
     end.join
+    assert PaperTrail.enabled?
+  end
+
+  test 'with_enabled' do
+    assert PaperTrail.enabled?
+    PaperTrail.with_enabled(false) do
+      refute PaperTrail.enabled?
+    end
     assert PaperTrail.enabled?
   end
 


### PR DESCRIPTION
atm if controller A sets whodunnit and then some other controller runs that does not include papertrail the whodunnit state lingers around, this also makes testing ugly since the whodunnit will randomly change and be lest in a bad state -> unrelated tests can fail.

These helpers should also be useful in general for background jobs or any task that does not want to change up global state.

@jaredbeck 