### PR TITLE
Use updated_at timestamp for "create" versions

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -326,8 +326,8 @@ module PaperTrail
             :event     => paper_trail_event || 'create',
             :whodunnit => PaperTrail.whodunnit
           }
-          if respond_to?(:created_at)
-            data[PaperTrail.timestamp_field] = created_at
+          if respond_to?(:updated_at)
+            data[PaperTrail.timestamp_field] = updated_at
           end
           if paper_trail_options[:save_changes] && changed_notably? && self.class.paper_trail_version_class.column_names.include?('object_changes')
             data[:object_changes] = self.class.paper_trail_version_class.object_changes_col_is_json? ? changes_for_paper_trail :


### PR DESCRIPTION
"Create" versions currently use the item's created_at field to set the version's timestamp. 

This is wrong in the case where the item was created at some point in the past, then deleted, then is now being created again (e.g., through reification). The version gets the timestamp from the original creation.

Instead, this change uses the item's updated_at field which is the time of the re-creation. This is also consistent with what happens in "update" versions