### PR TITLE
fix issue in #reify_has_many_through

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -417,7 +417,8 @@ module PaperTrail
       associations.each do |assoc|
         next unless assoc.klass.paper_trail_enabled_for_model?
         through_collection = model.send(assoc.options[:through])
-        collection_keys = through_collection.map { |through_model| through_model.send(assoc.foreign_key) }
+        #collect all the record_ids associated with the has_many through assoication
+        collection_keys = through_collection.map { |through_model| through_model.send(assoc.name).collect { |associated_model| associated_model.id} }.flatten
 
         version_id_subquery = assoc.klass.paper_trail_version_class.
           select("MIN(id)").


### PR DESCRIPTION
Fixed the code to collect the list of all the records that are associated with has_many through relationship.

through_collection => has the list of all the associated records that as associated directly.
assoc.name => returns the pluralised name of the associated model through the has_many association 

So I am iterating through all the directly associated records and fetching list of ids that are indirectly associated to our main model. 