### PR TITLE
fix issue in #reify_has_many_through

### DIFF
--- a/test/dummy/app/models/chapter.rb
+++ b/test/dummy/app/models/chapter.rb
@@ -1,0 +1,9 @@
+class Chapter < ActiveRecord::Base
+  has_many :sections, :dependent => :destroy
+  has_many :paragraphs, :through => :sections
+
+  has_many :quotations, :dependent => :destroy
+  has_many :citations, :through => :quotations
+
+  has_paper_trail
+end

--- a/test/dummy/app/models/citation.rb
+++ b/test/dummy/app/models/citation.rb
@@ -1,0 +1,5 @@
+class Citation < ActiveRecord::Base
+  belongs_to :quotation
+
+  has_paper_trail
+end

--- a/test/dummy/app/models/paragraph.rb
+++ b/test/dummy/app/models/paragraph.rb
@@ -1,0 +1,5 @@
+class Paragraph < ActiveRecord::Base
+  belongs_to :section
+
+  has_paper_trail
+end

--- a/test/dummy/app/models/quotation.rb
+++ b/test/dummy/app/models/quotation.rb
@@ -1,0 +1,5 @@
+class Quotation < ActiveRecord::Base
+  belongs_to :chapter
+  has_many :citations, :dependent => :destroy
+  has_paper_trail
+end

--- a/test/dummy/app/models/section.rb
+++ b/test/dummy/app/models/section.rb
@@ -1,0 +1,6 @@
+class Section < ActiveRecord::Base
+  belongs_to :chapter
+  has_many :paragraphs, :dependent => :destroy
+
+  has_paper_trail
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -211,9 +211,33 @@ class SetUpTestTables < ActiveRecord::Migration
       t.string :name
       t.boolean :scoped, :default => true
     end
+
+    create_table :chapters, :force => true do |t|
+      t.string :name
+    end
+
+    create_table :sections, :force => true do |t|
+      t.integer :chapter_id
+      t.string :name
+    end
+
+    create_table :paragraphs, :force => true do |t|
+      t.integer :section_id
+      t.string :name
+    end
+
+    create_table :quotations, :force => true do |t|
+      t.integer :chapter_id
+    end
+
+    create_table :citations, :force => true do |t|
+      t.integer :quotation_id
+    end
   end
 
   def self.down
+    drop_table :citations
+    drop_table :quotations
     drop_table :animals
     drop_table :skippers
     drop_table :not_on_updates
@@ -247,6 +271,9 @@ class SetUpTestTables < ActiveRecord::Migration
     drop_table :line_items
     drop_table :fruits
     drop_table :boolits
+    drop_table :chapters
+    drop_table :sections
+    drop_table :paragraphs
     remove_index :version_associations, :column => [:version_id]
     remove_index :version_associations, :name => 'index_version_associations_on_foreign_key'
     drop_table :version_associations

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1902,4 +1902,169 @@ class HasPaperTrailModelTransactionalTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "Models with nested has_many through relationships" do
+    setup { @chapter = Chapter.create(:name => 'ch_1') }
+
+    context "before any associations are created" do
+      setup do
+        @chapter.update_attributes(:name => "ch_2")
+        @ch_1 = @chapter.versions.last.reify(:has_many => true)
+      end
+
+      should "reify the record when reify is called" do
+        assert_equal "ch_1", @ch_1.name
+      end
+    end
+
+    context "after the first has_many through relationship is created" do
+      setup do
+        @chapter.update_attributes :name => "ch_2"
+        Timecop.travel 1.second.since
+        @chapter.sections.create :name => "section 1"
+        Timecop.travel 1.second.since
+        @chapter.sections.first.update_attributes :name => "section 2"
+        Timecop.travel 1.second.since
+        @chapter.update_attributes :name => "ch_3"
+        Timecop.travel 1.second.since
+        @chapter.sections.first.update_attributes :name => "section 3"
+      end
+
+      context "when reify is called" do
+        setup do
+          @chapter_2 = @chapter.versions.last.reify(:has_many => true)
+        end
+
+        should "show the value of the base record as it was before" do
+          assert_equal "ch_2", @chapter_2.name
+        end
+
+        should "show the value of the associated record as it was before the base record was updated" do
+          assert_equal ['section 2'], @chapter_2.sections.map(&:name)
+        end
+
+        context "to the version before the relationship was created" do
+          setup { @chapter_1 = @chapter.versions.second.reify(:has_many => true) }
+
+          should "not return any associated records" do
+            assert_equal 0, @chapter_1.sections.size
+          end
+        end
+
+        context "to the version before the associated record has been destroyed" do
+          setup do
+            @chapter.update_attributes :name => 'ch_3'
+            Timecop.travel 1.second.since
+            @chapter.sections.destroy_all
+            Timecop.travel 1.second.since
+            @chapter_3 = @chapter.versions.last.reify(:has_many => true)
+          end
+
+          should "return the associated record" do
+            assert_equal ['section 2'], @chapter_3.sections.map(&:name)
+          end
+        end
+
+        context "to the version after the associated record has been destroyed" do
+          setup do
+            @chapter.sections.destroy_all
+            Timecop.travel 1.second.since
+            @chapter.update_attributes :name => 'ch_4'
+            Timecop.travel 1.second.since
+            @chapter_4 = @chapter.versions.last.reify(:has_many => true)
+          end
+
+          should "return the associated record" do
+            assert_equal 0, @chapter_4.sections.size
+          end
+        end
+      end
+
+      context "after the nested has_many through relationship is created" do
+        setup do
+          @section = @chapter.sections.first
+          @paragraph = @section.paragraphs.create :name => 'para1'
+        end
+
+        context "reify the associations" do
+          setup do
+            Timecop.travel 1.second.since
+            @initial_section_name = @section.name
+            @initial_paragraph_name = @paragraph.name
+            @chapter.update_attributes :name => 'ch_5'
+            Timecop.travel 1.second.since
+            @paragraph.update_attributes :name => 'para3'
+            Timecop.travel 1.second.since
+            @chapter_4 = @chapter.versions.last.reify(:has_many => true)
+          end
+
+          should "to the version before the change was made" do
+            assert_equal [@initial_section_name], @chapter_4.sections.map(&:name)
+            assert_equal [@initial_paragraph_name], @chapter_4.sections.first.paragraphs.map(&:name)
+          end
+        end
+
+        context "and the first has_many through relationship is destroyed" do
+          setup do
+            @section.destroy
+            Timecop.travel 1.second.since
+            @chapter.update_attributes(:name => 'chapter 6')
+            Timecop.travel 1.second.since
+            @chapter_before = @chapter.versions.last.reify(:has_many => true)
+          end
+
+          should "reify should not return any associated models" do
+            assert_equal 0, @chapter_before.sections.size
+            assert_equal 0, @chapter_before.paragraphs.size
+          end
+        end
+
+        context "reified to the version before the nested has_many through relationship is destroyed" do
+          setup do
+            Timecop.travel 1.second.since
+            @initial_paragraph_name = @section.paragraphs.first.name
+            @chapter.update_attributes(:name => 'chapter 6')
+            Timecop.travel 1.second.since
+            @paragraph.destroy
+            @chapter_before = @chapter.versions.last.reify(:has_many => true)
+          end
+
+          should "restore the associated has_many relationship" do
+            assert_equal [@initial_paragraph_name], @chapter_before.sections.first.paragraphs.map(&:name)
+          end
+        end
+
+        context "reified to the version after the nested has_many through relationship is destroyed" do
+          setup do
+            @paragraph.destroy
+            Timecop.travel 1.second.since
+            @chapter.update_attributes(:name => 'chapter 6')
+            @chapter_before = @chapter.versions.last.reify(:has_many => true)
+          end
+
+          should "restore the associated has_many relationship" do
+            assert_equal [], @chapter_before.sections.first.paragraphs
+          end
+        end
+      end
+    end
+
+    context "a chapter with one paragraph and one citation" do
+      should "reify paragraphs and citations" do
+        chapter = Chapter.create(:name => 'Chapter One')
+        section = Section.create(:name => 'Section One', :chapter => chapter)
+        paragraph = Paragraph.create(:name => 'Paragraph One', :section => section)
+        quotation = Quotation.create(:chapter => chapter)
+        citation = Citation.create(:quotation => quotation)
+        Timecop.travel 1.second.since
+        chapter.update_attributes(:name => 'Chapter One, Vers. Two')
+        assert_equal 2, chapter.versions.count
+        paragraph.destroy
+        citation.destroy
+        reified = chapter.versions[1].reify(:has_many => true)
+        assert_equal [paragraph], reified.sections.first.paragraphs
+        assert_equal [citation], reified.quotations.first.citations
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix for https://github.com/airblade/paper_trail/issues/590

The assoc.foreign_key holds true only when the association is as follows

```ruby
Book
has_many :authorships
has_many :authors, :through => :authorships

Authorships
belongs_to :book
belongs_to :author

Author
has_many :authorships
has_many :books, :through => :authorships
```

In this case the assoc.foreign_key and assoc.association_foreign_key are the same

But in the case of the following associations

```ruby
Document
has_many :sections
has_many :paragraphs, :through => :sections

Section
belongs_to :document
has_many :paragraphs

Paragraph
belongs_to :section
```

the assoc.foreign_key and assoc.association_foreign_key are different and assoc.association_foreign_key gets the correct list of associated foreign_keys for the model.

For Ref: http://www.rubydoc.info/docs/rails/3.0.0/ActiveRecord%2FReflection%2FAssociationReflection%3Aassociation_foreign_key

EDIT: 
When a nested has_many relation is present, using the "reify_has_manys" method to reify the has_many through associations.