### PR TITLE
Stop testing against ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: ruby
 rvm:
   - 2.0.0
   - 1.9.3
-  - 1.8.7
   - jruby-19mode
-  - jruby-18mode
 env:
   global:
     - TRAVIS=true
@@ -29,11 +27,6 @@ gemfile:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: jruby-18mode
-      gemfile: Gemfile
-    - rvm: 1.8.7
-      gemfile: Gemfile
 
 addons:
   postgresql: "9.4"


### PR DESCRIPTION
PaperTrail 5 will not support ruby 1.8

See the conversation in https://github.com/airblade/paper_trail/pull/540