### PR TITLE
Specify required ruby version of 1.9 or greater

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.required_rubygems_version = '>= 1.3.6'
+  s.required_ruby_version = '>= 1.9'
 
   s.add_dependency 'activerecord', ['>= 3.0', '< 6.0']
   s.add_dependency 'activesupport', ['>= 3.0', '< 6.0']


### PR DESCRIPTION
On the Gemspec.. I meant to add this to the branch for #620 but didn't get around to it in time. We should add this in as well. Also I wonder whether we should hold off on merging the removal of 1.8.x into master until we get closer to v5.x?