### PR TITLE
Fixed typographical error, changed aganist to against in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,7 +1341,7 @@ require 'paper_trail/frameworks/rspec'
 
 Paper Trail has facilities to test against Postgres, Mysql and SQLite. To switch
 between DB engines you will need to export the DB variable for the engine you
-wish to test aganist.
+wish to test against.
 
 Though be aware we do not have the abilty to create the db's (except sqlite) for
 you. You can look at .travis.yml before_script for an example of how to create


### PR DESCRIPTION
@airblade, I've corrected a typographical error in the documentation of the [paper_trail](https://github.com/airblade/paper_trail) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.