### PR TITLE
Switch callbacks from `_filter` to `_action`

### DIFF
--- a/lib/paper_trail/frameworks/rails/controller.rb
+++ b/lib/paper_trail/frameworks/rails/controller.rb
@@ -3,9 +3,23 @@ module PaperTrail
     module Controller
 
       def self.included(base)
-        base.before_filter :set_paper_trail_enabled_for_controller
-        base.before_filter :set_paper_trail_controller_info
-        base.after_filter :warn_about_not_setting_whodunnit
+        before = [
+          :set_paper_trail_enabled_for_controller,
+          :set_paper_trail_controller_info,
+        ]
+        after = [
+          :warn_about_not_setting_whodunnit,
+        ]
+
+        if base.respond_to? :before_action
+          # Rails 4+
+          before.map {|sym| base.before_action sym }
+          after.map  {|sym| base.after_action  sym }
+        else
+          # Rails 3.
+          before.map {|sym| base.before_filter sym }
+          after.map  {|sym| base.after_filter  sym }
+        end
       end
 
       protected


### PR DESCRIPTION
Rails 5, in rails/rails@7644a99d, deprecated controller callbacks suffixed `_filter` in favour of those suffixed `_action`; this PR follows suit.