### PR TITLE
In track_associations, only check db if no config

### DIFF
--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -32,7 +32,9 @@ module PaperTrail
     end
 
     def track_associations
-      @track_associations ||= PaperTrail::VersionAssociation.table_exists?
+      @track_associations.nil? ?
+        PaperTrail::VersionAssociation.table_exists? :
+        @track_associations
     end
     alias_method :track_associations?, :track_associations
 


### PR DESCRIPTION
This allows users who need to precompile assets without a database
to configure `track_associations = false`.

See discussion: https://github.com/airblade/paper_trail/issues/636