### PR TITLE
Use class inst. var. instead of class var.

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -126,9 +126,9 @@ module PaperTrail
 
   # Returns PaperTrail's configuration object.
   def self.config
-    @@config ||= PaperTrail::Config.instance
-    yield @@config if block_given?
-    @@config
+    @config ||= PaperTrail::Config.instance
+    yield @config if block_given?
+    @config
   end
 
   class << self


### PR DESCRIPTION
I use the term "class instance variable" and "class variable"
even though `PaperTrail` is a module. This nomenclature is
conventional in ruby.

```ruby
module A; @@x = :x; puts defined?(@@x); end
#=> "class variable"
```

Actually, because `PaperTrail` is a module, the use of a class
variable here is not as problematic as in an actual class, so
this change is solely to conform the the Ruby Style Guide.

> Avoid the usage of class (@@) variables due to their "nasty"
> behavior in inheritance.
> https://github.com/bbatsov/ruby-style-guide#no-class-vars
