### PR TITLE
make 100% sure that the warning is accurate

### DIFF
--- a/lib/paper_trail/frameworks/rails/controller.rb
+++ b/lib/paper_trail/frameworks/rails/controller.rb
@@ -77,6 +77,7 @@ module PaperTrail
 
       # Tells PaperTrail who is responsible for any changes that occur.
       def set_paper_trail_whodunnit
+        @set_paper_trail_whodunnit_called=true
         ::PaperTrail.whodunnit = user_for_paper_trail if ::PaperTrail.enabled_for_controller?
       end
 
@@ -90,7 +91,7 @@ module PaperTrail
         enabled = ::PaperTrail.enabled_for_controller?
         user_present = user_for_paper_trail.present?
         whodunnit_blank = ::PaperTrail.whodunnit.blank?
-        if enabled && user_present && whodunnit_blank
+        if enabled && user_present && whodunnit_blank && !@set_paper_trail_whodunnit_called
           warn <<-EOS.strip_heredoc
             user_for_paper_trail is present, but whodunnit has not been set.
             PaperTrail no longer adds the set_paper_trail_whodunnit

--- a/lib/paper_trail/frameworks/sinatra.rb
+++ b/lib/paper_trail/frameworks/sinatra.rb
@@ -29,6 +29,7 @@ module PaperTrail
 
     # Tells PaperTrail who is responsible for any changes that occur.
     def set_paper_trail_whodunnit
+      @set_paper_trail_whodunnit_called=true
       ::PaperTrail.whodunnit = user_for_paper_trail if ::PaperTrail.enabled?
     end
 


### PR DESCRIPTION
This PR addresses this issue by making sure the warning is only displayed when in fact the before_filter for set_paper_trail_whodunnit was not installed.