### PR TITLE
Code style: break long lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,21 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   StyleGuideCopsOnly: false
+
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+# The Ruby Style Guide says:
+#
+# > Use \ instead of + or << to concatenate two string literals at line end.
+#
+# but in my experience the `\` style is rarely used and less readable. Please
+# concatenate multiline strings with `+` or use a HEREDOC.
+Style/LineEndConcatenation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 100

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,20 +46,13 @@ Metrics/BlockNesting:
 Metrics/CyclomaticComplexity:
   Max: 14
 
-# Offense count: 98
-# Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
-  Max: 147
-
 # Offense count: 15
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 51
 
-# Offense count: 3
-# Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 257
+  Enabled: false
 
 # Offense count: 7
 Metrics/PerceivedComplexity:
@@ -82,14 +75,6 @@ Style/Alias:
 Style/AlignHash:
   Exclude:
     - 'lib/generators/paper_trail/install_generator.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/AlignParameters:
-  Exclude:
-    - 'doc/bug_report_template.rb'
-    - 'lib/paper_trail/has_paper_trail.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -129,12 +114,6 @@ Style/DeprecatedHashMethods:
 # Offense count: 30
 # Configuration parameters: Exclude.
 Style/Documentation:
-  Enabled: false
-
-# Offense count: 31
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/DotPosition:
   Enabled: false
 
 # Offense count: 5
@@ -231,13 +210,6 @@ Style/Lambda:
   Exclude:
     - 'lib/paper_trail/has_paper_trail.rb'
     - 'lib/paper_trail/version_concern.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/LineEndConcatenation:
-  Exclude:
-    - 'lib/generators/paper_trail/install_generator.rb'
-    - 'lib/paper_trail/config.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/lib/generators/paper_trail/templates/create_version_associations.rb
+++ b/lib/generators/paper_trail/templates/create_version_associations.rb
@@ -6,12 +6,15 @@ class CreateVersionAssociations < ActiveRecord::Migration
       t.integer  :foreign_key_id
     end
     add_index :version_associations, [:version_id]
-    add_index :version_associations, [:foreign_key_name, :foreign_key_id], :name => 'index_version_associations_on_foreign_key'
+    add_index :version_associations,
+      [:foreign_key_name, :foreign_key_id],
+      :name => 'index_version_associations_on_foreign_key'
   end
 
   def self.down
     remove_index :version_associations, [:version_id]
-    remove_index :version_associations, :name => 'index_version_associations_on_foreign_key'
+    remove_index :version_associations,
+      :name => 'index_version_associations_on_foreign_key'
     drop_table :version_associations
   end
 end

--- a/lib/paper_trail/cleaner.rb
+++ b/lib/paper_trail/cleaner.rb
@@ -16,7 +16,7 @@ module PaperTrail
     def clean_versions!(options = {})
       options = {:keeping => 1, :date => :all}.merge(options)
       gather_versions(options[:item_id], options[:date]).each do |item_id, versions|
-        versions.group_by { |v| v.send(PaperTrail.timestamp_field).to_date }.each do |date, _versions|
+        group_versions_by_date(versions).each do |date, _versions|
           # Remove the number of versions we wish to keep from the collection
           # of versions prior to destruction.
           _versions.pop(options[:keeping])
@@ -40,6 +40,13 @@ module PaperTrail
       # do so now.
       versions = PaperTrail::Version.all if versions == PaperTrail::Version
       versions.group_by(&:item_id)
+    end
+
+    # Given an array of versions, returns a hash mapping dates to arrays of
+    # versions.
+    # @api private
+    def group_versions_by_date(versions)
+      versions.group_by { |v| v.send(PaperTrail.timestamp_field).to_date }
     end
   end
 end

--- a/lib/paper_trail/cleaner.rb
+++ b/lib/paper_trail/cleaner.rb
@@ -32,7 +32,9 @@ module PaperTrail
     # set, versions will be narrowed to those pointing at items with those ids
     # that were created on specified date.
     def gather_versions(item_id = nil, date = :all)
-      raise ArgumentError.new("`date` argument must receive a Timestamp or `:all`") unless date == :all || date.respond_to?(:to_date)
+      unless date == :all || date.respond_to?(:to_date)
+        raise ArgumentError.new("`date` argument must receive a Timestamp or `:all`")
+      end
       versions = item_id ? PaperTrail::Version.where(:item_id => item_id) : PaperTrail::Version
       versions = versions.between(date.to_date, date.to_date + 1.day) unless date == :all
 

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -40,7 +40,8 @@ module PaperTrail
 
     # Indicates whether PaperTrail is on or off.
     def enabled
-      PaperTrail.paper_trail_store[:paper_trail_enabled].nil? || PaperTrail.paper_trail_store[:paper_trail_enabled]
+      PaperTrail.paper_trail_store[:paper_trail_enabled].nil? ||
+        PaperTrail.paper_trail_store[:paper_trail_enabled]
     end
 
     def enabled= enable

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -38,10 +38,10 @@ module PaperTrail
     end
     alias_method :track_associations?, :track_associations
 
-    # Indicates whether PaperTrail is on or off.
+    # Indicates whether PaperTrail is on or off. Default: true.
     def enabled
-      PaperTrail.paper_trail_store[:paper_trail_enabled].nil? ||
-        PaperTrail.paper_trail_store[:paper_trail_enabled]
+      value = PaperTrail.paper_trail_store.fetch(:paper_trail_enabled, true)
+      value.nil? ? true : value
     end
 
     def enabled= enable

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -369,7 +369,7 @@ module PaperTrail
           if respond_to?(:updated_at)
             data[PaperTrail.timestamp_field] = updated_at
           end
-          if paper_trail_options[:save_changes] && changed_notably? && self.class.paper_trail_version_class.column_names.include?('object_changes')
+          if pt_record_object_changes? && changed_notably?
             data[:object_changes] = pt_recordable_object_changes
           end
           if self.class.paper_trail_version_class.column_names.include?('transaction_id')
@@ -391,7 +391,7 @@ module PaperTrail
           if respond_to?(:updated_at)
             data[PaperTrail.timestamp_field] = updated_at
           end
-          if paper_trail_options[:save_changes] && self.class.paper_trail_version_class.column_names.include?('object_changes')
+          if pt_record_object_changes?
             data[:object_changes] = pt_recordable_object_changes
           end
           if self.class.paper_trail_version_class.column_names.include?('transaction_id')
@@ -401,6 +401,14 @@ module PaperTrail
           set_transaction_id(version)
           save_associations(version)
         end
+      end
+
+      # Returns a boolean indicating whether to store serialized version diffs
+      # in the `object_changes` column of the version record.
+      # @api private
+      def pt_record_object_changes?
+        paper_trail_options[:save_changes] &&
+          self.class.paper_trail_version_class.column_names.include?('object_changes')
       end
 
       # Returns an object which can be assigned to the `object` attribute of a

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -370,8 +370,7 @@ module PaperTrail
             data[PaperTrail.timestamp_field] = updated_at
           end
           if paper_trail_options[:save_changes] && changed_notably? && self.class.paper_trail_version_class.column_names.include?('object_changes')
-            data[:object_changes] = self.class.paper_trail_version_class.object_changes_col_is_json? ? changes_for_paper_trail :
-              PaperTrail.serializer.dump(changes_for_paper_trail)
+            data[:object_changes] = pt_recordable_object_changes
           end
           if self.class.paper_trail_version_class.column_names.include?('transaction_id')
             data[:transaction_id] = PaperTrail.transaction_id
@@ -393,8 +392,7 @@ module PaperTrail
             data[PaperTrail.timestamp_field] = updated_at
           end
           if paper_trail_options[:save_changes] && self.class.paper_trail_version_class.column_names.include?('object_changes')
-            data[:object_changes] = self.class.paper_trail_version_class.object_changes_col_is_json? ? changes_for_paper_trail :
-              PaperTrail.serializer.dump(changes_for_paper_trail)
+            data[:object_changes] = pt_recordable_object_changes
           end
           if self.class.paper_trail_version_class.column_names.include?('transaction_id')
             data[:transaction_id] = PaperTrail.transaction_id
@@ -417,6 +415,20 @@ module PaperTrail
           object_attrs
         else
           PaperTrail.serializer.dump(object_attrs)
+        end
+      end
+
+      # Returns an object which can be assigned to the `object_changes`
+      # attribute of a nascent version record. If the `object_changes` column is
+      # a postgres `json` column, then a hash can be used in the assignment,
+      # otherwise the column is a `text` column, and we must perform the
+      # serialization here, using `PaperTrail.serializer`.
+      # @api private
+      def pt_recordable_object_changes
+        if self.class.paper_trail_version_class.object_changes_col_is_json?
+          changes_for_paper_trail
+        else
+          PaperTrail.serializer.dump(changes_for_paper_trail)
         end
       end
 

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -212,14 +212,7 @@ module PaperTrail
     # not have an `object_changes` text column.
     def changeset
       return nil unless self.class.column_names.include? 'object_changes'
-      _changes = HashWithIndifferentAccess.new(object_changes_deserialized)
-      @changeset ||= _changes.tap do |changes|
-        if PaperTrail.serialized_attributes?
-          item_type.constantize.unserialize_attribute_changes_for_paper_trail!(changes)
-        end
-      end
-    rescue
-      {}
+      @changeset ||= load_changeset
     end
 
     # Returns who put the item into the state stored in this version.
@@ -266,6 +259,17 @@ module PaperTrail
     # AFAICT it is not possible to have private instance methods in a mixin,
     # though private *class* methods are possible.
     private
+
+    # @api private
+    def load_changeset
+      changes = HashWithIndifferentAccess.new(object_changes_deserialized)
+      if PaperTrail.serialized_attributes?
+        item_type.constantize.unserialize_attribute_changes_for_paper_trail!(changes)
+      end
+      changes
+    rescue # TODO: Rescue something specific
+      {}
+    end
 
     # @api private
     def object_changes_deserialized

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -85,7 +85,8 @@ module PaperTrail
         end
 
         obj = obj.send(PaperTrail.timestamp_field) if obj.is_a?(self)
-        where(arel_table[PaperTrail.timestamp_field].lt(obj)).order(self.timestamp_sort_order('desc'))
+        where(arel_table[PaperTrail.timestamp_field].lt(obj)).
+          order(self.timestamp_sort_order('desc'))
       end
 
       def between(start_time, end_time)
@@ -136,7 +137,8 @@ module PaperTrail
           where_conditions = "object_changes @> '#{args.to_json}'::jsonb"
         elsif columns_hash['object'].type == :json
           where_conditions = args.map do |field, value|
-            "((object_changes->>'#{field}' ILIKE '[#{value.to_json},%') OR (object_changes->>'#{field}' ILIKE '[%,#{value.to_json}]%'))"
+            "((object_changes->>'#{field}' ILIKE '[#{value.to_json},%') " +
+              "OR (object_changes->>'#{field}' ILIKE '[%,#{value.to_json}]%'))"
           end
           where_conditions = where_conditions.join(" AND ")
         else

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -37,7 +37,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-nav', '~> 0.2.4'
   s.add_development_dependency 'rubocop', '~> 0.35.1'
 
-  # Allow time travel in testing. timecop is only supported after 1.9.2 but does a better cleanup at 'return'
+  # Allow time travel in testing. timecop is only supported after 1.9.2 but
+  # does a better cleanup at 'return'.
+  # TODO: We can remove delorean, as we no longer support ruby < 1.9.3
   if RUBY_VERSION < "1.9.2"
     s.add_development_dependency 'delorean'
   else

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+module PaperTrail
+  RSpec.describe Config do
+    describe ".instance" do
+      it "returns the singleton instance" do
+        expect { described_class.instance }.to_not raise_error
+      end
+    end
+
+    describe ".new" do
+      it "raises NoMethodError" do
+        expect { described_class.new }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "#enabled" do
+      context "when paper_trail_enabled is true" do
+        it "returns true" do
+          store = double
+          allow(store).to receive(:fetch).
+            with(:paper_trail_enabled, true).
+            and_return(true)
+          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
+          expect(described_class.instance.enabled).to eq(true)
+        end
+      end
+
+      context "when paper_trail_enabled is false" do
+        it "returns false" do
+          store = double
+          allow(store).to receive(:fetch).
+            with(:paper_trail_enabled, true).
+            and_return(false)
+          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
+          expect(described_class.instance.enabled).to eq(false)
+        end
+      end
+
+      context "when paper_trail_enabled is nil" do
+        it "returns true" do
+          store = double
+          allow(store).to receive(:fetch).
+            with(:paper_trail_enabled, true).
+            and_return(nil)
+          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
+          expect(described_class.instance.enabled).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Limits maximum line length to 100 characters.  The ruby style guide recommends 80 characters (https://github.com/bbatsov/ruby-style-guide#80-character-limits), but that would be a big undertaking.

In a few places, extracting a method was the best way to break a long line. I've made separate commits for each of those method extractions. Some of the new methods were hard to name. Also, I'm not thrilled about adding more methods to `PaperTrail::Model`. We already add a lot of clutter to people's AR models. I'm open to other ideas about where these methods could live.