### PR TITLE
Remove ruby 1.8 hacks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,12 +4,7 @@ Bundler::GemHelper.install_tasks
 desc 'Set a relevant database.yml for testing'
 task :prepare do
   ENV["DB"] ||= "sqlite"
-  if RUBY_VERSION >= '1.9'
-    FileUtils.cp "test/dummy/config/database.#{ENV["DB"]}.yml", "test/dummy/config/database.yml"
-  else
-    require 'ftools'
-    File.cp "test/dummy/config/database.#{ENV["DB"]}.yml", "test/dummy/config/database.yml"
-  end
+  FileUtils.cp "test/dummy/config/database.#{ENV["DB"]}.yml", "test/dummy/config/database.yml"
 end
 
 

--- a/gemfiles/3.0.gemfile
+++ b/gemfiles/3.0.gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'rubocop', '~> 0.35.1'
   gem 'shoulda', '~> 3.5'
   gem 'ffaker',  '<= 1.31.0'
+  gem 'timecop'
 
   # Testing of Rails
   gem 'railties', '~> 3.0'
@@ -23,13 +24,6 @@ group :development, :test do
 
   # To do proper transactional testing with ActiveSupport::TestCase on MySQL
   gem 'database_cleaner', '~> 1.2.0'
-
-  # Allow time travel in testing. timecop is only supported after 1.9.2 but does a better cleanup at 'return'
-  if RUBY_VERSION < "1.9.2"
-    gem 'delorean'
-  else
-    gem 'timecop'
-  end
 
   platforms :ruby do
     gem 'sqlite3', '~> 1.2'

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -36,15 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner', '~> 1.2'
   s.add_development_dependency 'pry-nav', '~> 0.2.4'
   s.add_development_dependency 'rubocop', '~> 0.35.1'
-
-  # Allow time travel in testing. timecop is only supported after 1.9.2 but
-  # does a better cleanup at 'return'.
-  # TODO: We can remove delorean, as we no longer support ruby < 1.9.3
-  if RUBY_VERSION < "1.9.2"
-    s.add_development_dependency 'delorean'
-  else
-    s.add_development_dependency 'timecop'
-  end
+  s.add_development_dependency 'timecop'
 
   # JRuby support for the test ENV
   unless defined?(JRUBY_VERSION)

--- a/spec/models/gadget_spec.rb
+++ b/spec/models/gadget_spec.rb
@@ -25,12 +25,7 @@ describe Gadget, :type => :model do
         describe '#changed_notably?' do
           subject { Gadget.new(:created_at => Time.now) }
 
-          # apparently the private methods list in Ruby18 is different than in Ruby19+
-          if RUBY_VERSION >= '1.9'
-            it { expect(subject.private_methods).to include(:changed_notably?) }
-          else
-            it { expect(subject.private_methods).to include('changed_notably?') }
-          end
+          it { expect(subject.private_methods).to include(:changed_notably?) }
 
           context "create events" do
             it { expect(subject.send(:changed_notably?)).to be true }

--- a/spec/support/alt_db_init.rb
+++ b/spec/support/alt_db_init.rb
@@ -2,21 +2,16 @@
 # then defines those namespaces, then establishes the sqlite3 connection for the namespaces
 # to simulate an application with multiple database connections.
 
-#Load database yaml to use
+# Load database yaml to use
 configs = YAML.load_file("#{Rails.root}/config/database.yml")
 
-#If we are testing with sqlite make it quick
+# If we are testing with sqlite make it quick
 db_directory = "#{Rails.root}/db"
-# setup alternate databases
+
+# Set up alternate databases
 if ENV["DB"] == "sqlite"
-  if  RUBY_VERSION >= '1.9'
-    FileUtils.cp "#{db_directory}/test.sqlite3", "#{db_directory}/test-foo.sqlite3"
-    FileUtils.cp "#{db_directory}/test.sqlite3", "#{db_directory}/test-bar.sqlite3"
-  else
-    require 'ftools'
-    File.cp "#{db_directory}/test.sqlite3", "#{db_directory}/test-foo.sqlite3"
-    File.cp "#{db_directory}/test.sqlite3", "#{db_directory}/test-bar.sqlite3"
-  end
+  FileUtils.cp "#{db_directory}/test.sqlite3", "#{db_directory}/test-foo.sqlite3"
+  FileUtils.cp "#{db_directory}/test.sqlite3", "#{db_directory}/test-bar.sqlite3"
 end
 
 module Foo

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -27,10 +27,6 @@ class ApplicationController < ActionController::Base
   private
 
   def modify_current_user
-    @current_user = OpenStruct.new(:id => 153).tap do |obj|
-      # Support ruby 1.8, in which `id` returns the `object_id`
-      # unless specifically overwritten.
-      def obj.id; 153; end if RUBY_VERSION < '1.9'
-    end
+    @current_user = OpenStruct.new(id: 153)
   end
 end

--- a/test/dummy/app/controllers/articles_controller.rb
+++ b/test/dummy/app/controllers/articles_controller.rb
@@ -9,9 +9,6 @@ class ArticlesController < ApplicationController
   end
 
   def current_user
-    'foobar'.tap do |string|
-      # Support ruby 1.8, in which `String` responds to `id`.
-      string.class_eval { undef_method(:id) } if RUBY_VERSION < '1.9'
-    end
+    'foobar'
   end
 end

--- a/test/functional/modular_sinatra_test.rb
+++ b/test/functional/modular_sinatra_test.rb
@@ -14,10 +14,7 @@ class BaseApp < Sinatra::Base
   end
 
   def current_user
-    @current_user ||= OpenStruct.new(:id => 'foobar').tap do |obj|
-      # Invoking `id` returns the `object_id` value in Ruby18 unless specifically overwritten
-      def obj.id; 'foobar'; end if RUBY_VERSION < '1.9'
-    end
+    @current_user ||= OpenStruct.new(id: 'foobar')
   end
 end
 
@@ -33,7 +30,7 @@ class ModularSinatraTest < ActionDispatch::IntegrationTest
   end
 
   context "`PaperTrail::Sinatra` in a `Sinatra::Base` application" do
-  
+
     should "sets the `user_for_paper_trail` from the `current_user` method" do
       get '/test'
       assert_equal 'Hello', last_response.body

--- a/test/functional/sinatra_test.rb
+++ b/test/functional/sinatra_test.rb
@@ -14,10 +14,7 @@ class Sinatra::Application
   end
 
   def current_user
-    @current_user ||= OpenStruct.new(:id => 'raboof').tap do |obj|
-      # Invoking `id` returns the `object_id` value in Ruby18 unless specifically overwritten
-      def obj.id; 'raboof'; end if RUBY_VERSION < '1.9'
-    end
+    @current_user ||= OpenStruct.new(id: 'raboof')
   end
 
 end

--- a/test/time_travel_helper.rb
+++ b/test/time_travel_helper.rb
@@ -1,15 +1,1 @@
-if RUBY_VERSION < "1.9.2"
-  require 'delorean'
-
-  class Timecop
-    def self.travel(t)
-      Delorean.time_travel_to t
-    end
-
-    def self.return
-      Delorean.back_to_the_present
-    end
-  end
-else
-  require 'timecop'
-end
+require 'timecop'

--- a/test/unit/protected_attrs_test.rb
+++ b/test/unit/protected_attrs_test.rb
@@ -35,8 +35,9 @@ class ProtectedAttrsTest < ActiveSupport::TestCase
       end
 
       should 'the previous version should contain right attributes' do
-        # For some reason this test seems to be broken in JRuby 1.9 mode in the test env even though it works in the console. WTF?
-        unless ActiveRecord::VERSION::MAJOR >= 4 && defined?(JRUBY_VERSION) && RUBY_VERSION >= '1.9'
+        # For some reason this test seems to be broken in JRuby 1.9 mode in the
+        # test env even though it works in the console. WTF?
+        unless ActiveRecord::VERSION::MAJOR >= 4 && defined?(JRUBY_VERSION)
           assert_equal @widget.previous_version.attributes, @initial_attributes
         end
       end

--- a/test/unit/serializer_test.rb
+++ b/test/unit/serializer_test.rb
@@ -22,11 +22,7 @@ class SerializerTest < ActiveSupport::TestCase
 
       # Check values are stored as `YAML`.
       assert_equal @original_fluxor_attributes, YAML.load(@fluxor.versions[1].object)
-      # This test can't consistently pass in Ruby1.8 because hashes do no preserve order, which means the order of the
-      # attributes in the `YAML` can't be ensured.
-      if RUBY_VERSION >= '1.9'
-        assert_equal YAML.dump(@original_fluxor_attributes), @fluxor.versions[1].object
-      end
+      assert_equal YAML.dump(@original_fluxor_attributes), @fluxor.versions[1].object
     end
   end
 
@@ -57,11 +53,7 @@ class SerializerTest < ActiveSupport::TestCase
 
       # Check values are stored as JSON.
       assert_equal @original_fluxor_attributes, ActiveSupport::JSON.decode(@fluxor.versions[1].object)
-      # This test can't consistently pass in Ruby1.8 because hashes do no preserve order, which means the order of the
-      # attributes in the JSON can't be ensured.
-      if RUBY_VERSION >= '1.9'
-        assert_equal ActiveSupport::JSON.encode(@original_fluxor_attributes), @fluxor.versions[1].object
-      end
+      assert_equal ActiveSupport::JSON.encode(@original_fluxor_attributes), @fluxor.versions[1].object
     end
 
     should 'store object_changes' do
@@ -99,11 +91,7 @@ class SerializerTest < ActiveSupport::TestCase
 
       # Check values are stored as JSON.
       assert_equal @original_fluxor_attributes, ActiveSupport::JSON.decode(@fluxor.versions[1].object)
-      # This test can't consistently pass in Ruby1.8 because hashes do no preserve order, which means the order of the
-      # attributes in the JSON can't be ensured.
-      if RUBY_VERSION >= '1.9'
-        assert_equal ActiveSupport::JSON.encode(@original_fluxor_attributes), @fluxor.versions[1].object
-      end
+      assert_equal ActiveSupport::JSON.encode(@original_fluxor_attributes), @fluxor.versions[1].object
     end
 
     should 'store object_changes' do
@@ -113,5 +101,4 @@ class SerializerTest < ActiveSupport::TestCase
       assert_equal second_changeset,  @fluxor.versions[1].changeset
     end
   end
-
 end


### PR DESCRIPTION
PaperTrail no longer supports ruby 1.8.