### PR TITLE
[#43] Save object for create event

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -296,6 +296,7 @@ module PaperTrail
         if paper_trail_switched_on?
           data = {
             :event     => paper_trail_event || 'create',
+            :object    => pt_recordable_object_for_create,
             :whodunnit => PaperTrail.whodunnit
           }
           if respond_to?(:updated_at)
@@ -351,6 +352,21 @@ module PaperTrail
       # @api private
       def pt_recordable_object
         object_attrs = object_attrs_for_paper_trail(attributes_before_change)
+        if self.class.paper_trail_version_class.object_col_is_json?
+          object_attrs
+        else
+          PaperTrail.serializer.dump(object_attrs)
+        end
+      end
+
+      # Returns an object which can be assigned to the `object` attribute of a
+      # nascent version record. If the `object` column is a postgres `json`
+      # column, then a hash can be used in the assignment, otherwise the column
+      # is a `text` column, and we must perform the serialization here, using
+      # `PaperTrail.serializer`.
+      # @api private
+      def pt_recordable_object_for_create
+        object_attrs = object_attrs_for_paper_trail(attributes)
         if self.class.paper_trail_version_class.object_col_is_json?
           object_attrs
         else

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -201,7 +201,7 @@ module PaperTrail
     #   - `:preserve` - Attributes undefined in version record are not modified.
     #
     def reify(options = {})
-      return nil if object.nil?
+      return nil if event == 'create'
       without_identity_map do
         ::PaperTrail::Reifier.reify(self, options)
       end

--- a/spec/models/json_version_spec.rb
+++ b/spec/models/json_version_spec.rb
@@ -35,7 +35,7 @@ if JsonVersion.table_exists?
             end
 
             it "should be able to locate versions according to their `object` contents" do
-              expect(JsonVersion.where_object(:name => name)).to eq([fruit.versions[1]])
+              expect(JsonVersion.where_object(:name => name)).to eq(fruit.versions[0..1])
               expect(JsonVersion.where_object(:color => color)).to eq([fruit.versions[2]])
             end
           end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -147,20 +147,20 @@ describe PaperTrail::Version, :type => :model do
 
             context "valid arguments", :versioning => true do
               let(:widget) { Widget.new }
-              let(:name) { FFaker::Name.first_name }
+              let(:name) { 'test1' }
               let(:int) { rand(10) + 1 }
 
               before do
                 widget.update_attributes!(:name => name, :an_integer => int)
-                widget.update_attributes!(:name => 'foobar', :an_integer => 100)
-                widget.update_attributes!(:name => FFaker::Name.last_name, :an_integer => 15)
+                widget.update_attributes!(:name => 'test2', :an_integer => 100)
+                widget.update_attributes!(:name => 'test3', :an_integer => 15)
               end
 
               context "`serializer == YAML`" do
                 specify { expect(PaperTrail.serializer).to be PaperTrail::Serializers::YAML }
 
                 it "should be able to locate versions according to their `object` contents" do
-                  expect(PaperTrail::Version.where_object(:name => name)).to eq([widget.versions[1]])
+                  expect(PaperTrail::Version.where_object(:name => name)).to eq(widget.versions[0..1])
                   expect(PaperTrail::Version.where_object(:an_integer => 100)).to eq([widget.versions[2]])
                 end
               end
@@ -170,7 +170,7 @@ describe PaperTrail::Version, :type => :model do
                 specify { expect(PaperTrail.serializer).to be PaperTrail::Serializers::JSON }
 
                 it "should be able to locate versions according to their `object` contents" do
-                  expect(PaperTrail::Version.where_object(:name => name)).to eq([widget.versions[1]])
+                  expect(PaperTrail::Version.where_object(:name => name)).to eq(widget.versions[0..1])
                   expect(PaperTrail::Version.where_object(:an_integer => 100)).to eq([widget.versions[2]])
                 end
 

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -200,7 +200,6 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       end
 
       should 'be nil in its previous version' do
-        assert_nil @widget.versions.first.object
         assert_nil @widget.versions.first.reify
       end
 


### PR DESCRIPTION
Saving object params for create event, so when you search for event by params, like

```ruby
PaperTrail::Version.where_object(:name => name)
```

it will also return `create` event. While `reify` for `create` event still returns `nil`.


