### PR TITLE
Deprecate PaperTrail.serialized_attributes?

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -24,11 +24,12 @@ module PaperTrail
     !!PaperTrail.config.enabled
   end
 
-  # ActiveRecord 5 drops support for serialized attributes; for previous
-  # versions of ActiveRecord it is supported, we have a config option
-  # to enable it within PaperTrail.
   def self.serialized_attributes?
-    !!PaperTrail.config.serialized_attributes && ::ActiveRecord::VERSION::MAJOR < 5
+    ActiveSupport::Deprecation.warn(
+      "PaperTrail.serialized_attributes? is deprecated without replacement " +
+        "and always returns false."
+    )
+    false
   end
 
   # Sets whether PaperTrail is enabled or disabled for the current request.

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -14,15 +14,16 @@ module PaperTrail
 
     def serialized_attributes
       ActiveSupport::Deprecation.warn(
-        "PaperTrail.config.serialized_attributes is deprecated without " \
-        "replacement and no longer has any effect."
+        "PaperTrail.config.serialized_attributes is deprecated without " +
+          "replacement and always returns false."
       )
+      false
     end
 
     def serialized_attributes=(_)
       ActiveSupport::Deprecation.warn(
-        "PaperTrail.config.serialized_attributes= is deprecated without " \
-        "replacement and no longer has any effect."
+        "PaperTrail.config.serialized_attributes= is deprecated without " +
+          "replacement and no longer has any effect."
       )
     end
 


### PR DESCRIPTION
This is a follow-up to https://github.com/airblade/paper_trail/pull/667
"Use Active Record's type system from 4.2 onwards."