### PR TITLE
Specify query order in STI test

### DIFF
--- a/test/unit/inheritance_column_test.rb
+++ b/test/unit/inheritance_column_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class InheritanceColumnTest < ActiveSupport::TestCase
-
   context 'STI models' do
     setup do
       @animal = Animal.create :name => 'Animal'
@@ -28,16 +27,17 @@ class InheritanceColumnTest < ActiveSupport::TestCase
 
       # For some reason `@dog.versions` doesn't include the final `destroy` version.
       # Neither do `@dog.versions.scoped` nor `@dog.versions(true)` nor `@dog.versions.reload`.
-      dog_versions = PaperTrail::Version.where(:item_id => @dog.id)
+      dog_versions = PaperTrail::Version.where(:item_id => @dog.id).
+        order(PaperTrail.timestamp_field)
       assert_equal 4, dog_versions.count
       assert_nil dog_versions.first.reify
-      dog_versions[1..-1].each { |v| assert_equal 'Dog', v.reify.class.name }
+      assert_equal %w[NilClass Dog Dog Dog], dog_versions.map { |v| v.reify.class.name }
 
-      cat_versions = PaperTrail::Version.where(:item_id => @cat.id)
+      cat_versions = PaperTrail::Version.where(:item_id => @cat.id).
+        order(PaperTrail.timestamp_field)
       assert_equal 4, cat_versions.count
       assert_nil cat_versions.first.reify
-      cat_versions[1..-1].each { |v| assert_equal 'Cat', v.reify.class.name }
+      assert_equal %w[NilClass Cat Cat Cat], cat_versions.map { |v| v.reify.class.name }
     end
   end
-
 end


### PR DESCRIPTION
This fixes an intermittent test failure where query sometimes
returned records in an order other than that in which they
were created. This is not a bug. Without an order clause, SQL
queries are expected to return records in any order.

Fixes https://github.com/airblade/paper_trail/issues/672