### PR TITLE
Call #reload instead of passing 'true' to relations

### DIFF
--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -189,7 +189,7 @@ module PaperTrail
             group("item_id").
             to_sql
           versions = versions_by_id(model.class, version_id_subquery)
-          collection = Array.new model.send(assoc.name, true) # pass true to avoid cache
+          collection = Array.new model.send(assoc.name).reload # to avoid cache
           prepare_array_for_has_many(collection, options, versions)
           model.send(assoc.name).proxy_association.target = collection
         end

--- a/test/unit/associations_test.rb
+++ b/test/unit/associations_test.rb
@@ -46,7 +46,7 @@ class AssociationsTest < ActiveSupport::TestCase
         end
 
         should 'not persist changes to the live association' do
-          assert_equal @wotsit, @widget.wotsit(true)
+          assert_equal @wotsit, @widget.reload.wotsit
         end
       end
     end
@@ -66,7 +66,7 @@ class AssociationsTest < ActiveSupport::TestCase
         end
 
         should 'not persist changes to the live association' do
-          assert_equal @wotsit, @widget.wotsit(true)
+          assert_equal @wotsit, @widget.reload.wotsit
         end
       end
 
@@ -87,7 +87,7 @@ class AssociationsTest < ActiveSupport::TestCase
           end
 
           should 'not persist changes to the live association' do
-            assert_equal 'wotsit_3', @widget.wotsit(true).name
+            assert_equal 'wotsit_3', @widget.reload.wotsit.name
           end
         end
 
@@ -113,7 +113,7 @@ class AssociationsTest < ActiveSupport::TestCase
           end
 
           should 'not persist changes to the live association' do
-            assert_nil @widget.wotsit(true)
+            assert_nil @widget.reload.wotsit
           end
         end
 
@@ -152,7 +152,7 @@ class AssociationsTest < ActiveSupport::TestCase
         end
 
         should 'not persist changes to the live association' do
-          assert_not_equal [], @customer.orders(true)
+          assert_not_equal [], @customer.orders.reload
         end
       end
 
@@ -211,7 +211,7 @@ class AssociationsTest < ActiveSupport::TestCase
           end
 
           should 'not persist changes to the live association' do
-            assert_equal ['order_date_3'], @customer.orders(true).map(&:order_date)
+            assert_equal ['order_date_3'], @customer.orders.reload.map(&:order_date)
           end
         end
 
@@ -236,7 +236,7 @@ class AssociationsTest < ActiveSupport::TestCase
             end
 
             should 'not persist changes to the live association' do
-              assert_equal [], @customer.orders(true)
+              assert_equal [], @customer.orders.reload
             end
           end
         end
@@ -255,7 +255,7 @@ class AssociationsTest < ActiveSupport::TestCase
           end
 
           should 'not persist changes to the live association' do
-            assert_equal [], @customer.orders(true)
+            assert_equal [], @customer.orders.reload
           end
         end
       end
@@ -289,7 +289,7 @@ class AssociationsTest < ActiveSupport::TestCase
           end
 
           should 'not persist changes to the live association' do
-            assert_equal ['order_date_0', 'order_date_1'], @customer.orders(true).map(&:order_date).sort
+            assert_equal ['order_date_0', 'order_date_1'], @customer.orders.reload.map(&:order_date).sort
           end
         end
 
@@ -322,7 +322,7 @@ class AssociationsTest < ActiveSupport::TestCase
           end
 
           should 'not persist changes to the live association' do
-            assert_equal ['author_0'], @book.authors(true).map(&:name)
+            assert_equal ['author_0'], @book.authors.reload.map(&:name)
           end
         end
 
@@ -401,7 +401,7 @@ class AssociationsTest < ActiveSupport::TestCase
             end
 
             should 'not persist changes to the live association' do
-              assert_equal ['author_3'], @book.authors(true).map(&:name)
+              assert_equal ['author_3'], @book.authors.reload.map(&:name)
             end
           end
 
@@ -427,7 +427,7 @@ class AssociationsTest < ActiveSupport::TestCase
             end
 
             should 'not persist changes to the live association' do
-              assert_equal [], @book.authors(true)
+              assert_equal [], @book.authors.reload
             end
           end
         end
@@ -477,7 +477,7 @@ class AssociationsTest < ActiveSupport::TestCase
             end
 
             should 'not persist changes to the live association' do
-              assert_equal ['author_0', 'author_1'], @book.authors(true).map(&:name)
+              assert_equal ['author_0', 'author_1'], @book.authors.reload.map(&:name)
             end
           end
 
@@ -507,7 +507,7 @@ class AssociationsTest < ActiveSupport::TestCase
             end
 
             should 'not persist changes to the live association' do
-              assert_equal ['author_0', 'person_existing'], @book.authors(true).map(&:name).sort
+              assert_equal ['author_0', 'person_existing'], @book.authors.reload.map(&:name).sort
             end
           end
 

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -56,7 +56,7 @@ class PaperTrailCleanerTest < ActiveSupport::TestCase
         assert_equal 3, @animal.versions_between(@date, @date + 1.day).size
         PaperTrail.clean_versions!(:date => @date)
         assert_equal 8, PaperTrail::Version.count
-        assert_equal 2, @animal.versions(true).size
+        assert_equal 2, @animal.versions.reload.size
         assert_equal @date, @animal.versions.first.created_at.to_date
         assert_not_same @date, @animal.versions.last.created_at.to_date
       end
@@ -154,7 +154,7 @@ class PaperTrailCleanerTest < ActiveSupport::TestCase
         end
       end
       PaperTrail.timestamp_field = :custom_created_at
-      @animals.map { |a| a.versions(true) } # reload the `versions` association for each animal
+      @animals.map { |a| a.versions.reload } # reload the `versions` association for each animal
     end
 
     teardown do

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -305,13 +305,13 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
           should 'not copy the has_one association by default when reifying' do
             reified_widget = @widget.versions.last.reify
             assert_equal @wotsit, reified_widget.wotsit  # association hasn't been affected by reifying
-            assert_equal @wotsit, @widget.wotsit(true)  # confirm that the association is correct
+            assert_equal @wotsit, @widget.reload.wotsit  # confirm that the association is correct
           end
 
           should 'copy the has_one association when reifying with :has_one => true' do
             reified_widget = @widget.versions.last.reify(:has_one => true)
             assert_nil reified_widget.wotsit  # wotsit wasn't there at the last version
-            assert_equal @wotsit, @widget.wotsit(true)  # wotsit should still exist on live object
+            assert_equal @wotsit, @widget.reload.wotsit  # wotsit should still exist on live object
           end
         end
 
@@ -962,7 +962,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     should 'store version on join destroy' do
       @book.authors << @dostoyevsky
       count = PaperTrail::Version.count
-      @book.authorships(true).last.destroy
+      @book.authorships.reload.last.destroy
       assert_equal 1, PaperTrail::Version.count - count
       assert_equal @book, PaperTrail::Version.last.reify.book
       assert_equal @dostoyevsky, PaperTrail::Version.last.reify.person
@@ -971,7 +971,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     should 'store version on join clear' do
       @book.authors << @dostoyevsky
       count = PaperTrail::Version.count
-      @book.authorships(true).destroy_all
+      @book.authorships.reload.destroy_all
       assert_equal 1, PaperTrail::Version.count - count
       assert_equal @book, PaperTrail::Version.last.reify.book
       assert_equal @dostoyevsky, PaperTrail::Version.last.reify.person

--- a/test/unit/timestamp_test.rb
+++ b/test/unit/timestamp_test.rb
@@ -34,7 +34,7 @@ class TimestampTest < ActiveSupport::TestCase
     end
 
     # Test we are ordering by custom timestamps.
-    @fluxor.versions true  # reload association
+    @fluxor.versions.reload # reload association
     assert_nil @fluxor.versions[2].reify
     assert_equal 'Some text.', @fluxor.versions[1].reify.name
     assert_equal 'Some more text.', @fluxor.versions[0].reify.name


### PR DESCRIPTION
> Passing a truthy argument to force association to reload
> will be removed in Rails 5.1.
> https://github.com/rails/rails/blob/master/activerecord/CHANGELOG.md