### PR TITLE
Backport 033b135 to 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 4.0.2
+
+### Breaking Changes
+
+- None
+
+### Added
+
+- None
+
+### Fixed
+
+- [#696](https://github.com/airblade/paper_trail/issues/696) /
+  [#697](https://github.com/airblade/paper_trail/pull/697)
+  Bind JSON query parameters in `where_object` and `where_object_changes`.
+
 ## 4.0.1
 
 ### Breaking Changes

--- a/gemfiles/3.0.gemfile
+++ b/gemfiles/3.0.gemfile
@@ -30,9 +30,14 @@ group :development, :test do
     gem 'timecop'
   end
 
-  platforms :ruby do 
+  platforms :ruby do
     gem 'sqlite3', '~> 1.2'
-    gem 'mysql2', '~> 0.3'
+
+    # We would prefer to only constrain mysql2 to '~> 0.3',
+    # but a rails bug (https://github.com/rails/rails/issues/21544)
+    # requires us to constrain to '~> 0.3.20' for now.
+    gem 'mysql2', '~> 0.3.20'
+
     gem 'pg', '~> 0.17.1'
   end
 
@@ -42,7 +47,7 @@ group :development, :test do
     gem 'shoulda-matchers', '~> 1.5'
   end
 
-  platforms :jruby do 
+  platforms :jruby do
     # Use jRuby's sqlite3 adapter for jRuby
     gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3'
     gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3'

--- a/gemfiles/3.0.gemfile
+++ b/gemfiles/3.0.gemfile
@@ -23,10 +23,13 @@ group :development, :test do
   # To do proper transactional testing with ActiveSupport::TestCase on MySQL
   gem 'database_cleaner', '~> 1.2.0'
 
-  # Allow time travel in testing. timecop is only supported after 1.9.2 but does a better cleanup at 'return'
   if RUBY_VERSION < "1.9.2"
     gem 'delorean'
+
+    # rack-cache 1.3 drops ruby 1.8.7 support
+    gem 'rack-cache', '1.2'
   else
+    # timecop is only supported after 1.9.2 but does a better cleanup at 'return'
     gem 'timecop'
   end
 

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -34,10 +34,13 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'generator_spec'
   s.add_development_dependency 'database_cleaner', '~> 1.2'
 
-  # Allow time travel in testing. timecop is only supported after 1.9.2 but does a better cleanup at 'return'
   if RUBY_VERSION < "1.9.2"
     s.add_development_dependency 'delorean'
+
+    # rack-cache 1.3 drops ruby 1.8.7 support
+    s.add_development_dependency 'rack-cache', '1.2'
   else
+    # timecop is only supported after 1.9.2 but does a better cleanup at 'return'
     s.add_development_dependency 'timecop'
   end
 

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -44,7 +44,12 @@ Gem::Specification.new do |s|
   # JRuby support for the test ENV
   unless defined?(JRUBY_VERSION)
     s.add_development_dependency 'sqlite3', '~> 1.2'
-    s.add_development_dependency 'mysql2', '~> 0.3'
+
+    # We would prefer to only constrain mysql2 to '~> 0.3',
+    # but a rails bug (https://github.com/rails/rails/issues/21544)
+    # requires us to constrain to '~> 0.3.20' for now.
+    s.add_development_dependency 'mysql2', '~> 0.3.20'
+
     s.add_development_dependency 'pg', '~> 0.17'
   else
     s.add_development_dependency 'activerecord-jdbcsqlite3-adapter', '~> 1.3'

--- a/spec/models/json_version_spec.rb
+++ b/spec/models/json_version_spec.rb
@@ -13,6 +13,16 @@ if JsonVersion.table_exists?
         describe '#where_object' do
           it { expect(JsonVersion).to respond_to(:where_object) }
 
+          it "escapes values" do
+            f = Fruit.create(:name => 'Bobby')
+            expect(
+              f.
+                versions.
+                where_object(:name => "Robert'; DROP TABLE Students;--").
+                count
+            ).to eq(0)
+          end
+
           context "invalid arguments" do
             it "should raise an error" do
               expect { JsonVersion.where_object(:foo) }.to raise_error(ArgumentError)
@@ -41,6 +51,16 @@ if JsonVersion.table_exists?
 
         describe '#where_object_changes' do
           it { expect(JsonVersion).to respond_to(:where_object_changes) }
+
+          it "escapes values" do
+            f = Fruit.create(:name => 'Bobby')
+            expect(
+              f.
+                versions.
+                where_object_changes(:name => "Robert'; DROP TABLE Students;--").
+                count
+            ).to eq(0)
+          end
 
           context "invalid arguments" do
             it "should raise an error" do

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -442,7 +442,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
     end
 
     should 'handle decimals' do
-      assert_in_delta 2.71828, @previous.a_decimal, 0.00001
+      assert_in_delta 2.7183, @previous.a_decimal, 0.0001
     end
 
     should 'handle datetimes' do
@@ -484,7 +484,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         assert_equal    'The quick brown fox',       @last.reify.a_text
         assert_equal    42,                          @last.reify.an_integer
         assert_in_delta 153.01,                      @last.reify.a_float,   0.001
-        assert_in_delta 2.71828,                     @last.reify.a_decimal, 0.00001
+        assert_in_delta 2.7183,                      @last.reify.a_decimal, 0.0001
         assert_equal    @date_time.to_time.utc.to_i, @last.reify.a_datetime.to_time.utc.to_i
         assert_equal    @time.utc.to_i,              @last.reify.a_time.utc.to_i
         assert_equal    @date,                       @last.reify.a_date


### PR DESCRIPTION
This PR is solely concerned with backporting 033b135 to `4.0-stable`. However, it's been a while since we've run the 4.0 test suite, and a few things need to be updated.