### PR TITLE
Fix link to Custom Serializer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ has been destroyed.
   - [Storing metadata](#storing-metadata)
 - Extensibility
   - [Custom Version Classes](#custom-version-classes)
-  - [Custom Serializer](#using-a-custom-serializer)
+  - [Custom Serializer](#custom-serializer)
 - [Testing](#testing)
 - [Sinatra](#sinatra)
 


### PR DESCRIPTION
Looks like the heading changed at some point, not allowing one to easily click down to that section