### PR TITLE
Add a way to disable in all threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,13 @@
   [#614](https://github.com/airblade/paper_trail/pull/614)
 - Added `unversioned_attributes` option to `reify`.
   [#579](https://github.com/airblade/paper_trail/pull/579)
+- Added a `config.paper_trail.enabled` option for controlling PaperTrail from the environment config.
+  [#695](https://github.com/airblade/paper_trail/pull/695)
 
 ### Fixed
 
-- None
+- Fixed deprecation warning for Active Record after_callback / after_commit
+  [#695](https://github.com/airblade/paper_trail/pull/695)
 
 ## 4.0.2 (2016-01-19)
 

--- a/README.md
+++ b/README.md
@@ -415,52 +415,27 @@ class.
 
 ### Globally
 
-On a global level you can turn PaperTrail off like this:
+On a thread global level you can turn PaperTrail off like this:
 
 ```ruby
 PaperTrail.enabled = false
 ```
 
-For example, you might want to disable PaperTrail in your Rails application's
-test environment to speed up your tests.  This will do it (note: this gets done
-automatically for `RSpec` and `Cucumber`, please see the [Testing
-section](#testing)):
+### Per Rails Environment
+
+You might want to disable PaperTrail in your Rails application's test
+environment to speed up your tests. This is done automatically for `RSpec` and
+`Cucumber`.
 
 ```ruby
-# in config/environments/test.rb
-config.after_initialize do
-  PaperTrail.enabled = false
-end
+# config/environments/test.rb
+config.paper_trail.enabled = false
 ```
 
-If you disable PaperTrail in your test environment but want to enable it for
-specific tests, you can add a helper like this to your test helper:
+The value provided will simply be passed to `PaperTrail#enabled=` during rails
+initialization.
 
-```ruby
-# in test/test_helper.rb
-def with_versioning
-  was_enabled = PaperTrail.enabled?
-  was_enabled_for_controller = PaperTrail.enabled_for_controller?
-  PaperTrail.enabled = true
-  PaperTrail.enabled_for_controller = true
-  begin
-    yield
-  ensure
-    PaperTrail.enabled = was_enabled
-    PaperTrail.enabled_for_controller = was_enabled_for_controller
-  end
-end
-```
-
-And then use it in your tests like this:
-
-```ruby
-test "something that needs versioning" do
-  with_versioning do
-    # your test
-  end
-end
-```
+See the [Testing section](#testing) for more tips.
 
 ### Per request
 
@@ -674,7 +649,7 @@ For diffing two ActiveRecord objects:
 * [activerecord-diff][23]: rather like ActiveRecord::Dirty but also allows you
   to specify which columns to compare.
 
-If you wish to selectively record changes for some models but not others you
+If you want to selectively record changes for some models but not others you
 can opt out of recording changes by passing `:save_changes => false` to your
 `has_paper_trail` method declaration.
 
@@ -1204,17 +1179,53 @@ end
 
 ## Testing
 
-You may want to turn PaperTrail off to speed up your tests.  See the [Turning
-PaperTrail Off/On](#turning-papertrail-offon) section above for tips on usage
-with `Test::Unit`.
+You may want to turn PaperTrail off to speed up your tests.
+
+### Rails
+
+```ruby
+# config/environments/test.rb
+config.paper_trail.enabled = false
+```
+
+See [Turning PaperTrail Off/On](#turning-papertrail-offon) for details.
+
+### Test::Unit
+
+If you disable PaperTrail in your test environment but want to enable it for
+specific tests, you can add a helper like this to your test helper:
+
+```ruby
+# in test/test_helper.rb
+def with_versioning
+  was_enabled = PaperTrail.enabled?
+  was_enabled_for_controller = PaperTrail.enabled_for_controller?
+  PaperTrail.enabled = true
+  PaperTrail.enabled_for_controller = true
+  begin
+    yield
+  ensure
+    PaperTrail.enabled = was_enabled
+    PaperTrail.enabled_for_controller = was_enabled_for_controller
+  end
+end
+```
+
+And then use it in your tests like this:
+
+```ruby
+test "something that needs versioning" do
+  with_versioning do
+    # your test
+  end
+end
+```
 
 ### RSpec
 
-PaperTrail provides a helper that works with [RSpec][27] to make it easier to
-control when `PaperTrail` is enabled during testing.
-
-If you wish to use the helper, you will need to require it in your RSpec test
-helper like so:
+PaperTrail provides a optional helper that works with [RSpec][27] to make it
+easier to selectively enable `PaperTrail` during testing. The file is
+`paper_trail/frameworks/rspec.rb`. If you want to use the helper, `require` it.
 
 ```ruby
 # spec/rails_helper.rb
@@ -1228,7 +1239,7 @@ require 'paper_trail/frameworks/rspec'
 ```
 
 When the helper is loaded, PaperTrail will be turned off for all tests by
-default. When you wish to enable PaperTrail for a test you can either wrap the
+default. When you want to enable PaperTrail for a test you can either wrap the
 test in a `with_versioning` block, or pass in `:versioning => true` option to a
 spec block, like so:
 
@@ -1304,7 +1315,7 @@ matcher
 ### Cucumber
 
 PaperTrail provides a helper for [Cucumber][28] that works similar to the RSpec
-helper.If you wish to use the helper, you will need to require in your cucumber
+helper.If you want to use the helper, you will need to require in your cucumber
 helper like so:
 
 ```ruby
@@ -1317,7 +1328,7 @@ require 'paper_trail/frameworks/cucumber'
 ```
 
 When the helper is loaded, PaperTrail will be turned off for all scenarios by a
-`before` hook added by the helper by default. When you wish to enable PaperTrail
+`before` hook added by the helper by default. When you want to enable PaperTrail
 for a scenario, you can wrap code in a `with_versioning` block in a step, like
 so:
 
@@ -1336,7 +1347,7 @@ value to `{}` as well, again, to help prevent data spillover between tests.
 
 ### Spork
 
-If you wish to use the `RSpec` or `Cucumber` helpers with [Spork][29], you will
+If you want to use the `RSpec` or `Cucumber` helpers with [Spork][29], you will
 need to manually require the helper(s) in your `prefork` block on your test
 helper, like so:
 
@@ -1359,7 +1370,7 @@ end
 
 ### Zeus or Spring
 
-If you wish to use the `RSpec` or `Cucumber` helpers with [Zeus][30] or
+If you want to use the `RSpec` or `Cucumber` helpers with [Zeus][30] or
 [Spring][31], you will need to manually require the helper(s) in your test
 helper, like so:
 
@@ -1377,7 +1388,7 @@ require 'paper_trail/frameworks/rspec'
 
 Paper Trail has facilities to test against Postgres, Mysql and SQLite. To switch
 between DB engines you will need to export the DB variable for the engine you
-wish to test against.
+want to test against.
 
 Though be aware we do not have the ability to create the db's (except sqlite) for
 you. You can look at .travis.yml before_script for an example of how to create

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -16,15 +16,31 @@ module PaperTrail
   class << self
     # Switches PaperTrail on or off.
     # @api public
+    # @deprecated in 5.0
     def enabled=(value)
-      PaperTrail.config.enabled = value
+      ::ActiveSupport::Deprecation.warn "Use enabled_in_current_thread=", caller(1)
+      PaperTrail.config.enabled_in_current_thread = value
+    end
+
+    # Not thread-safe. See also `enabled_in_current_thread=`, which is.
+    # @api public
+    def enabled_in_all_threads= value
+      PaperTrail.config.enabled_in_all_threads = value
+    end
+
+    # Enable or disable PaperTrail in the current thread. Ignored if
+    # PaperTrail is disabled globally. See also `enabled_in_all_threads=`,
+    # which is not thread-safe.
+    # @api public
+    def enabled_in_current_thread= value
+      PaperTrail.config.enabled_in_current_thread = value
     end
 
     # Returns `true` if PaperTrail is on, `false` otherwise.
     # PaperTrail is enabled by default.
     # @api public
     def enabled?
-      !!PaperTrail.config.enabled
+      PaperTrail.config.enabled?
     end
 
     def serialized_attributes?
@@ -168,10 +184,6 @@ unless PaperTrail.active_record_protected_attributes?
   rescue LoadError # rubocop:disable Lint/HandleExceptions
     # In case `protected_attributes` gem is not available.
   end
-end
-
-ActiveSupport.on_load(:active_record) do
-  include PaperTrail::Model
 end
 
 # Require frameworks

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -5,11 +5,12 @@ module PaperTrail
   class Config
     include Singleton
     attr_accessor :timestamp_field, :serializer, :version_limit
-    attr_writer :track_associations
+    attr_writer :enabled_in_all_threads, :track_associations
 
     def initialize
       @timestamp_field = :created_at
       @serializer      = PaperTrail::Serializers::YAML
+      @enabled_in_all_threads = true
     end
 
     def serialized_attributes
@@ -34,14 +35,41 @@ module PaperTrail
     end
     alias_method :track_associations?, :track_associations
 
-    # Indicates whether PaperTrail is on or off. Default: true.
+    # @api public
+    # @deprecated in 5.0
     def enabled
-      value = PaperTrail.paper_trail_store.fetch(:paper_trail_enabled, true)
-      value.nil? ? true : value
+      ::ActiveSupport::Deprecation.warn "Use enabled? (with question mark)", caller(1)
+      enabled?
     end
 
+    # @api public
+    def enabled?
+      !!(@enabled_in_all_threads && enabled_in_current_thread?)
+    end
+
+    # @api public
+    # @deprecated in 5.0
     def enabled= enable
+      ::ActiveSupport::Deprecation.warn "Use enabled_in_current_thread=", caller(1)
+      self.enabled_in_current_thread = enable
+    end
+
+    # Enable or disable PaperTrail in the current thread. Ignored if
+    # PaperTrail is disabled globally. See also `enabled_in_all_threads=`,
+    # which is not thread-safe.
+    # @api public
+    def enabled_in_current_thread= enable
       PaperTrail.paper_trail_store[:paper_trail_enabled] = enable
+    end
+
+    private
+
+    # Irrespective of whether PaperTrail is enabled globally, returns a boolean
+    # indicating if PaperTrail is enabled for the current thread.
+    # @api private
+    def enabled_in_current_thread?
+      value = PaperTrail.paper_trail_store.fetch(:paper_trail_enabled, true)
+      value.nil? ? true : value
     end
   end
 end

--- a/lib/paper_trail/frameworks/active_record.rb
+++ b/lib/paper_trail/frameworks/active_record.rb
@@ -1,4 +1,11 @@
 # This file only needs to be loaded if the gem is being used outside of Rails,
-# since otherwise the model(s) will get loaded in via the `Rails::Engine`.
+# since otherwise the model(s) will be configured for autoloading by
+# `PaperTrail::Rails::Engine`.
 require "paper_trail/frameworks/active_record/models/paper_trail/version_association"
 require "paper_trail/frameworks/active_record/models/paper_trail/version"
+
+# Likewise, in rails, the inclusion of `PaperTrail::Model` into `ActiveRecord`
+# would be done by `PaperTrail::Rails::Engine`.
+ActiveSupport.on_load(:active_record) do
+  include PaperTrail::Model
+end

--- a/lib/paper_trail/frameworks/rails/engine.rb
+++ b/lib/paper_trail/frameworks/rails/engine.rb
@@ -2,6 +2,11 @@ module PaperTrail
   module Rails
     class Engine < ::Rails::Engine
       paths['app/models'] << 'lib/paper_trail/frameworks/active_record/models'
+      config.paper_trail = ActiveSupport::OrderedOptions.new
+      initializer 'paper_trail.initialisation' do |app|
+        ActiveRecord::Base.send :include, PaperTrail::Model
+        PaperTrail.enabled_in_all_threads = app.config.paper_trail.fetch(:enabled, true)
+      end
     end
   end
 end

--- a/lib/paper_trail/frameworks/rspec.rb
+++ b/lib/paper_trail/frameworks/rspec.rb
@@ -7,14 +7,14 @@ RSpec.configure do |config|
   config.extend ::PaperTrail::RSpec::Helpers::ClassMethods
 
   config.before(:each) do
-    ::PaperTrail.enabled = false
+    ::PaperTrail.enabled_in_current_thread = false
     ::PaperTrail.enabled_for_controller = true
     ::PaperTrail.whodunnit = nil
     ::PaperTrail.controller_info = {} if defined?(::Rails) && defined?(::RSpec::Rails)
   end
 
   config.before(:each, versioning: true) do
-    ::PaperTrail.enabled = true
+    ::PaperTrail.enabled_in_current_thread = true
   end
 end
 

--- a/lib/paper_trail/frameworks/rspec/helpers.rb
+++ b/lib/paper_trail/frameworks/rspec/helpers.rb
@@ -5,10 +5,10 @@ module PaperTrail
         # enable versioning for specific blocks (at instance-level)
         def with_versioning
           was_enabled = ::PaperTrail.enabled?
-          ::PaperTrail.enabled = true
+          ::PaperTrail.enabled_in_current_thread = true
           yield
         ensure
-          ::PaperTrail.enabled = was_enabled
+          ::PaperTrail.enabled_in_current_thread = was_enabled
         end
       end
 

--- a/spec/modules/paper_trail_spec.rb
+++ b/spec/modules/paper_trail_spec.rb
@@ -5,15 +5,15 @@ describe PaperTrail, type: :module, versioning: true do
     it { is_expected.to respond_to(:config) }
 
     it "should allow for config values to be set" do
-      expect(subject.config.enabled).to eq(true)
-      subject.config.enabled = false
-      expect(subject.config.enabled).to eq(false)
+      expect(subject.config.enabled?).to eq(true)
+      subject.config.enabled_in_current_thread = false
+      expect(subject.config.enabled?).to eq(false)
     end
 
     it "should accept blocks and yield the config instance" do
-      expect(subject.config.enabled).to eq(true)
-      subject.config { |c| c.enabled = false }
-      expect(subject.config.enabled).to eq(false)
+      expect(subject.config.enabled?).to eq(true)
+      subject.config { |c| c.enabled_in_current_thread = false }
+      expect(subject.config.enabled?).to eq(false)
     end
   end
 

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -14,7 +14,7 @@ module PaperTrail
       end
     end
 
-    describe "#enabled" do
+    describe "#enabled?" do
       context "when paper_trail_enabled is true" do
         it "returns true" do
           store = double
@@ -22,7 +22,7 @@ module PaperTrail
             with(:paper_trail_enabled, true).
             and_return(true)
           allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(true)
+          expect(described_class.instance.enabled?).to eq(true)
         end
       end
 
@@ -33,7 +33,7 @@ module PaperTrail
             with(:paper_trail_enabled, true).
             and_return(false)
           allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(false)
+          expect(described_class.instance.enabled?).to eq(false)
         end
       end
 
@@ -44,7 +44,7 @@ module PaperTrail
             with(:paper_trail_enabled, true).
             and_return(nil)
           allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(true)
+          expect(described_class.instance.enabled?).to eq(true)
         end
       end
     end

--- a/test/functional/enabled_for_controller_test.rb
+++ b/test/functional/enabled_for_controller_test.rb
@@ -5,24 +5,28 @@ class EnabledForControllerTest < ActionController::TestCase
 
   context "`PaperTrail.enabled? == true`" do
     should 'enabled_for_controller?.should == true' do
-      assert PaperTrail.enabled?
+      assert_equal true, PaperTrail.enabled?
       post :create, params_wrapper(article: { title: 'Doh', content: FFaker::Lorem.sentence })
       assert_not_nil assigns(:article)
-      assert PaperTrail.enabled_for_controller?
+      assert_equal true, PaperTrail.enabled_for_controller?
       assert_equal 1, assigns(:article).versions.length
     end
   end
 
   context "`PaperTrail.enabled? == false`" do
-    setup { PaperTrail.enabled = false }
+    setup do
+      PaperTrail.enabled_in_current_thread = false
+    end
 
     should 'enabled_for_controller?.should == false' do
-      assert !PaperTrail.enabled?
+      assert_equal false, PaperTrail.enabled?
       post :create, params_wrapper(article: { title: 'Doh', content: FFaker::Lorem.sentence })
-      assert !PaperTrail.enabled_for_controller?
+      assert_equal false, PaperTrail.enabled_for_controller?
       assert_equal 0, assigns(:article).versions.length
     end
 
-    teardown { PaperTrail.enabled = true }
+    teardown do
+      PaperTrail.enabled_in_current_thread = true
+    end
   end
 end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -543,13 +543,13 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
   context 'A record' do
     setup { @widget = Widget.create name: 'Zaphod' }
 
-    context 'with PaperTrail globally disabled' do
+    context 'with PaperTrail disabled' do
       setup do
-        PaperTrail.enabled = false
+        PaperTrail.enabled_in_current_thread = false
         @count = @widget.versions.length
       end
 
-      teardown { PaperTrail.enabled = true }
+      teardown { PaperTrail.enabled_in_current_thread = true }
 
       context 'when updated' do
         setup { @widget.update_attributes name: 'Beeblebrox' }


### PR DESCRIPTION
Expands on @Hermanverschooten's suggestion in https://github.com/airblade/paper_trail/pull/695, adds a way to disable PT in all threads, hopefully fixes https://github.com/airblade/paper_trail/issues/635.

Initially, I was concerned about having both a thread-safe flag and thread-unsafe flag.  This PR mitigates that concern by giving these methods very explicit names, like `enabled_in_all_threads=` and `enabled_in_current_thread=`.

- Renames config methods to clarify which are thread-safe and which are not. Deprecates old methods whose names were unclear.
- Adds rails config option: `config.paper_trail.enabled`. See initializer in `paper_trail/frameworks/rails/engine.rb`
- Organizes docs re: the many ways of disabling

Ben, I liked your suggestion in https://github.com/airblade/paper_trail/issues/635 that the all-threads flag be immutable, but I didn't see immediately how to implement said immutability given the way we apply the rails config option in `engine.rb`.