### PR TITLE
An idea to combat model pollution

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,10 +17,6 @@ Metrics/AbcSize:
   Exclude:
     - 'test/dummy/db/migrate/*'
 
-Metrics/ClassLength:
-  Exclude:
-    - test/**/*
-
 # The Ruby Style Guide recommends to "Limit lines to 80 characters."
 # (https://github.com/bbatsov/ruby-style-guide#80-character-limits)
 # but 100 is also reasonable.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -4,11 +4,16 @@
 Metrics/AbcSize:
   Max: 30 # Goal: 15
 
+Metrics/ClassLength:
+  Max: 400
+  Exclude:
+    - test/**/*
+
 Metrics/CyclomaticComplexity:
   Max: 13 # Goal: 6
 
 Metrics/ModuleLength:
-  Max: 313
+  Max: 317
 
 Metrics/PerceivedComplexity:
   Max: 16 # Goal: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 5.?.? (Unreleased)
+## 5.2.0 (Unreleased)
 
 ### Breaking Changes
 
 - None
+
+### Deprecated
+
+- [#719](https://github.com/airblade/paper_trail/pull/719) -
+  The majority of model methods. Use paper_trail.x instead of x. Why? Your
+  models are a crowded namespace, and we want to get out of your way!
 
 ### Added
 

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -16,6 +16,11 @@ module PaperTrail
   extend PaperTrail::Cleaner
 
   class << self
+    # @api private
+    def clear_transaction_id
+      self.transaction_id = nil
+    end
+
     # Switches PaperTrail on or off.
     # @api public
     def enabled=(value)

--- a/lib/paper_trail/attribute_serializers/object_attribute.rb
+++ b/lib/paper_trail/attribute_serializers/object_attribute.rb
@@ -32,7 +32,7 @@ module PaperTrail
       end
 
       def object_col_is_json?
-        @model_class.paper_trail_version_class.object_col_is_json?
+        @model_class.paper_trail.version_class.object_col_is_json?
       end
     end
   end

--- a/lib/paper_trail/attribute_serializers/object_changes_attribute.rb
+++ b/lib/paper_trail/attribute_serializers/object_changes_attribute.rb
@@ -35,7 +35,7 @@ module PaperTrail
       end
 
       def object_changes_col_is_json?
-        @item_class.paper_trail_version_class.object_changes_col_is_json?
+        @item_class.paper_trail.version_class.object_changes_col_is_json?
       end
     end
   end

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -1,0 +1,195 @@
+require "active_support/core_ext"
+
+module PaperTrail
+  # Configures an ActiveRecord model, mostly at application boot time, but also
+  # sometimes mid-request, with methods like enable/disable.
+  class ModelConfig
+    E_CANNOT_RECORD_AFTER_DESTROY = <<-STR.strip_heredoc.freeze
+      paper_trail.on_destroy(:after) is incompatible with ActiveRecord's
+      belongs_to_required_by_default and has no effect. Please use :before
+      or disable belongs_to_required_by_default.
+    STR
+
+    def initialize(model_class)
+      @model_class = model_class
+    end
+
+    # Switches PaperTrail off for this class.
+    def disable
+      ::PaperTrail.enabled_for_model(@model_class, false)
+    end
+
+    # Switches PaperTrail on for this class.
+    def enable
+      ::PaperTrail.enabled_for_model(@model_class, true)
+    end
+
+    def enabled?
+      return false unless @model_class.include?(::PaperTrail::Model::InstanceMethods)
+      ::PaperTrail.enabled_for_model?(@model_class)
+    end
+
+    # Adds a callback that records a version after a "create" event.
+    def on_create
+      @model_class.after_create :record_create, if: ->(m) { m.paper_trail.save_version? }
+      return if @model_class.paper_trail_options[:on].include?(:create)
+      @model_class.paper_trail_options[:on] << :create
+    end
+
+    # Adds a callback that records a version before or after a "destroy" event.
+    def on_destroy(recording_order = "before")
+      unless %w(after before).include?(recording_order.to_s)
+        raise ArgumentError, 'recording order can only be "after" or "before"'
+      end
+
+      if recording_order.to_s == "after" && cannot_record_after_destroy?
+        ::ActiveSupport::Deprecation.warn(E_CANNOT_RECORD_AFTER_DESTROY)
+      end
+
+      @model_class.send "#{recording_order}_destroy", :record_destroy,
+        if: ->(m) { m.paper_trail.save_version? }
+
+      return if @model_class.paper_trail_options[:on].include?(:destroy)
+      @model_class.paper_trail_options[:on] << :destroy
+    end
+
+    # Adds a callback that records a version after an "update" event.
+    def on_update
+      @model_class.before_save :reset_timestamp_attrs_for_update_if_needed!, on: :update
+      @model_class.after_update :record_update, if: ->(m) { m.paper_trail.save_version? }
+      @model_class.after_update :clear_version_instance!
+      return if @model_class.paper_trail_options[:on].include?(:update)
+      @model_class.paper_trail_options[:on] << :update
+    end
+
+    # Set up `@model_class` for PaperTrail. Installs callbacks, associations,
+    # "class attributes", instance methods, and more.
+    # @api private
+    def setup(options = {})
+      options[:on] ||= [:create, :update, :destroy]
+      options[:on] = Array(options[:on]) # Support single symbol
+      @model_class.send :include, ::PaperTrail::Model::InstanceMethods
+      if ::ActiveRecord::VERSION::STRING < "4.2"
+        @model_class.send :extend, AttributeSerializers::LegacyActiveRecordShim
+      end
+      setup_options(options)
+      setup_associations(options)
+      setup_transaction_callbacks
+      setup_callbacks_from_options options[:on]
+      setup_callbacks_for_habtm options[:join_tables]
+    end
+
+    def version_class
+      @_version_class ||= @model_class.version_class_name.constantize
+    end
+
+    private
+
+    def active_record_gem_version
+      Gem::Version.new(ActiveRecord::VERSION::STRING)
+    end
+
+    def cannot_record_after_destroy?
+      Gem::Version.new(ActiveRecord::VERSION::STRING).release >= Gem::Version.new("5") &&
+        ::ActiveRecord::Base.belongs_to_required_by_default
+    end
+
+    def setup_associations(options)
+      @model_class.class_attribute :version_association_name
+      @model_class.version_association_name = options[:version] || :version
+
+      # The version this instance was reified from.
+      @model_class.send :attr_accessor, @model_class.version_association_name
+
+      @model_class.class_attribute :version_class_name
+      @model_class.version_class_name = options[:class_name] || "PaperTrail::Version"
+
+      @model_class.class_attribute :versions_association_name
+      @model_class.versions_association_name = options[:versions] || :versions
+
+      @model_class.send :attr_accessor, :paper_trail_event
+
+      # In rails 4, the `has_many` syntax for specifying order uses a lambda.
+      if ::ActiveRecord::VERSION::MAJOR >= 4
+        @model_class.has_many(
+          @model_class.versions_association_name,
+          -> { order(model.timestamp_sort_order) },
+          class_name: @model_class.version_class_name,
+          as: :item
+        )
+      else
+        @model_class.has_many(
+          @model_class.versions_association_name,
+          class_name: @model_class.version_class_name,
+          as: :item,
+          order: @model_class.paper_trail_version_class.timestamp_sort_order
+        )
+      end
+    end
+
+    # Adds callbacks to record changes to habtm associations such that on save
+    # the previous version of the association (if changed) can be interpreted.
+    def setup_callbacks_for_habtm(join_tables)
+      @model_class.send :attr_accessor, :paper_trail_habtm
+      @model_class.class_attribute :paper_trail_save_join_tables
+      @model_class.paper_trail_save_join_tables = Array.wrap(join_tables)
+      @model_class.reflect_on_all_associations(:has_and_belongs_to_many).
+        reject { |a| @model_class.paper_trail_options[:skip].include?(a.name.to_s) }.
+        each { |a|
+          added_callback = lambda do |*args|
+            update_habtm_state(a.name, :before_add, args[-2], args.last)
+          end
+          removed_callback = lambda do |*args|
+            update_habtm_state(a.name, :before_remove, args[-2], args.last)
+          end
+          @model_class.send(:"before_add_for_#{a.name}").send(:<<, added_callback)
+          @model_class.send(:"before_remove_for_#{a.name}").send(:<<, removed_callback)
+        }
+    end
+
+    def setup_callbacks_from_options(options_on = [])
+      options_on.each do |event|
+        public_send("on_#{event}")
+      end
+    end
+
+    def setup_options(options)
+      @model_class.class_attribute :paper_trail_options
+      @model_class.paper_trail_options = options.dup
+
+      [:ignore, :skip, :only].each do |k|
+        @model_class.paper_trail_options[k] = [@model_class.paper_trail_options[k]].
+          flatten.
+          compact.
+          map { |attr| attr.is_a?(Hash) ? attr.stringify_keys : attr.to_s }
+      end
+
+      @model_class.paper_trail_options[:meta] ||= {}
+      if @model_class.paper_trail_options[:save_changes].nil?
+        @model_class.paper_trail_options[:save_changes] = true
+      end
+    end
+
+    # Reset the transaction id when the transaction is closed.
+    def setup_transaction_callbacks
+      @model_class.after_commit { PaperTrail.clear_transaction_id }
+      @model_class.after_rollback { PaperTrail.clear_transaction_id }
+      @model_class.after_rollback { paper_trail.clear_rolled_back_versions }
+    end
+
+    def update_habtm_state(name, callback, model, assoc)
+      model.paper_trail_habtm ||= {}
+      model.paper_trail_habtm.reverse_merge!(name => { removed: [], added: [] })
+      case callback
+      when :before_add
+        model.paper_trail_habtm[name][:added] |= [assoc.id]
+        model.paper_trail_habtm[name][:removed] -= [assoc.id]
+      when :before_remove
+        model.paper_trail_habtm[name][:removed] |= [assoc.id]
+        model.paper_trail_habtm[name][:added] -= [assoc.id]
+      else
+        raise "Invalid callback: #{callback}"
+      end
+    end
+  end
+end

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -1,0 +1,450 @@
+module PaperTrail
+  # Represents the "paper trail" for a single record.
+  class RecordTrail
+    def initialize(record)
+      @record = record
+    end
+
+    # Utility method for reifying. Anything executed inside the block will
+    # appear like a new record.
+    def appear_as_new_record
+      @record.instance_eval {
+        alias :old_new_record? :new_record?
+        alias :new_record? :present?
+      }
+      yield
+      @record.instance_eval { alias :new_record? :old_new_record? }
+    end
+
+    def attributes_before_change
+      changed = @record.changed_attributes.select { |k, _v|
+        @record.class.column_names.include?(k)
+      }
+      @record.attributes.merge(changed)
+    end
+
+    def changed_and_not_ignored
+      ignore = @record.paper_trail_options[:ignore].dup
+      # Remove Hash arguments and then evaluate whether the attributes (the
+      # keys of the hash) should also get pushed into the collection.
+      ignore.delete_if do |obj|
+        obj.is_a?(Hash) &&
+          obj.each { |attr, condition|
+            ignore << attr if condition.respond_to?(:call) && condition.call(@record)
+          }
+      end
+      skip = @record.paper_trail_options[:skip]
+      @record.changed - ignore - skip
+    end
+
+    # Invoked after rollbacks to ensure versions records are not created for
+    # changes that never actually took place. Optimization: Use lazy `reset`
+    # instead of eager `reload` because, in many use cases, the association will
+    # not be used.
+    def clear_rolled_back_versions
+      versions.reset
+    end
+
+    # Invoked via`after_update` callback for when a previous version is
+    # reified and then saved.
+    def clear_version_instance
+      @record.send("#{@record.class.version_association_name}=", nil)
+    end
+
+    # Determines whether it is appropriate to generate a new version
+    # instance. A timestamp-only update (e.g. only `updated_at` changed) is
+    # considered notable unless an ignored attribute was also changed.
+    def changed_notably?
+      if ignored_attr_has_changed?
+        timestamps = @record.send(:timestamp_attributes_for_update_in_model).map(&:to_s)
+        (notably_changed - timestamps).any?
+      else
+        notably_changed.any?
+      end
+    end
+
+    # @api private
+    def changes
+      notable_changes = @record.changes.delete_if { |k, _v|
+        !notably_changed.include?(k)
+      }
+      AttributeSerializers::ObjectChangesAttribute.
+        new(@record.class).
+        serialize(notable_changes)
+      notable_changes.to_hash
+    end
+
+    def enabled?
+      PaperTrail.enabled? && PaperTrail.enabled_for_controller? && enabled_for_model?
+    end
+
+    def enabled_for_model?
+      @record.class.paper_trail.enabled?
+    end
+
+    # An attributed is "ignored" if it is listed in the `:ignore` option
+    # and/or the `:skip` option.  Returns true if an ignored attribute has
+    # changed.
+    def ignored_attr_has_changed?
+      ignored = @record.paper_trail_options[:ignore] + @record.paper_trail_options[:skip]
+      ignored.any? && (@record.changed & ignored).any?
+    end
+
+    # Returns true if this instance is the current, live one;
+    # returns false if this instance came from a previous version.
+    def live?
+      source_version.nil?
+    end
+
+    # @api private
+    def merge_metadata(data)
+      # First we merge the model-level metadata in `meta`.
+      @record.paper_trail_options[:meta].each do |k, v|
+        data[k] =
+          if v.respond_to?(:call)
+            v.call(@record)
+          elsif v.is_a?(Symbol) && @record.respond_to?(v, true)
+            # If it is an attribute that is changing in an existing object,
+            # be sure to grab the current version.
+            if @record.has_attribute?(v) &&
+                @record.send("#{v}_changed?".to_sym) &&
+                data[:event] != "create"
+              @record.send("#{v}_was".to_sym)
+            else
+              @record.send(v)
+            end
+          else
+            v
+          end
+      end
+
+      # Second we merge any extra data from the controller (if available).
+      data.merge(PaperTrail.controller_info || {})
+    end
+
+    # Returns the object (not a Version) as it became next.
+    # NOTE: if self (the item) was not reified from a version, i.e. it is the
+    #  "live" item, we return nil.  Perhaps we should return self instead?
+    def next_version
+      subsequent_version = source_version.next
+      subsequent_version ? subsequent_version.reify : @record.class.find(@record.id)
+    rescue # TODO: Rescue something more specific
+      nil
+    end
+
+    def notably_changed
+      only = @record.paper_trail_options[:only].dup
+      # Remove Hash arguments and then evaluate whether the attributes (the
+      # keys of the hash) should also get pushed into the collection.
+      only.delete_if do |obj|
+        obj.is_a?(Hash) &&
+          obj.each { |attr, condition|
+            only << attr if condition.respond_to?(:call) && condition.call(@record)
+          }
+      end
+      only.empty? ? changed_and_not_ignored : (changed_and_not_ignored & only)
+    end
+
+    # Returns hash of attributes (with appropriate attributes serialized),
+    # omitting attributes to be skipped.
+    def object_attrs_for_paper_trail
+      attrs = attributes_before_change.except(*@record.paper_trail_options[:skip])
+      AttributeSerializers::ObjectAttribute.new(@record.class).serialize(attrs)
+      attrs
+    end
+
+    # Returns who put `@record` into its current state.
+    def originator
+      (source_version || versions.last).try(:whodunnit)
+    end
+
+    # Returns the object (not a Version) as it was most recently.
+    def previous_version
+      (source_version ? source_version.previous : versions.last).try(:reify)
+    end
+
+    def record_create
+      return unless enabled?
+      data = {
+        event: @record.paper_trail_event || "create",
+        whodunnit: PaperTrail.whodunnit
+      }
+      if @record.respond_to?(:updated_at)
+        data[PaperTrail.timestamp_field] = @record.updated_at
+      end
+      if record_object_changes? && changed_notably?
+        data[:object_changes] = recordable_object_changes
+      end
+      add_transaction_id_to(data)
+      versions_assoc = @record.send(@record.class.versions_association_name)
+      version = versions_assoc.create! merge_metadata(data)
+      update_transaction_id(version)
+      save_associations(version)
+    end
+
+    def record_destroy
+      if enabled? && !@record.new_record?
+        data = {
+          item_id: @record.id,
+          item_type: @record.class.base_class.name,
+          event: @record.paper_trail_event || "destroy",
+          object: recordable_object,
+          whodunnit: PaperTrail.whodunnit
+        }
+        add_transaction_id_to(data)
+        version = @record.class.paper_trail.version_class.create(merge_metadata(data))
+        if version.errors.any?
+          log_version_errors(version, :destroy)
+        else
+          @record.send("#{@record.class.version_association_name}=", version)
+          @record.send(@record.class.versions_association_name).reset
+          update_transaction_id(version)
+          save_associations(version)
+        end
+      end
+    end
+
+    # Returns a boolean indicating whether to store serialized version diffs
+    # in the `object_changes` column of the version record.
+    # @api private
+    def record_object_changes?
+      @record.paper_trail_options[:save_changes] &&
+        @record.class.paper_trail.version_class.column_names.include?("object_changes")
+    end
+
+    def record_update(force)
+      if enabled? && (force || changed_notably?)
+        data = {
+          event: @record.paper_trail_event || "update",
+          object: recordable_object,
+          whodunnit: PaperTrail.whodunnit
+        }
+        if @record.respond_to?(:updated_at)
+          data[PaperTrail.timestamp_field] = @record.updated_at
+        end
+        if record_object_changes?
+          data[:object_changes] = recordable_object_changes
+        end
+        add_transaction_id_to(data)
+        versions_assoc = @record.send(@record.class.versions_association_name)
+        version = versions_assoc.create(merge_metadata(data))
+        if version.errors.any?
+          log_version_errors(version, :update)
+        else
+          update_transaction_id(version)
+          save_associations(version)
+        end
+      end
+    end
+
+    # Returns an object which can be assigned to the `object` attribute of a
+    # nascent version record. If the `object` column is a postgres `json`
+    # column, then a hash can be used in the assignment, otherwise the column
+    # is a `text` column, and we must perform the serialization here, using
+    # `PaperTrail.serializer`.
+    # @api private
+    def recordable_object
+      if @record.class.paper_trail.version_class.object_col_is_json?
+        object_attrs_for_paper_trail
+      else
+        PaperTrail.serializer.dump(object_attrs_for_paper_trail)
+      end
+    end
+
+    # Returns an object which can be assigned to the `object_changes`
+    # attribute of a nascent version record. If the `object_changes` column is
+    # a postgres `json` column, then a hash can be used in the assignment,
+    # otherwise the column is a `text` column, and we must perform the
+    # serialization here, using `PaperTrail.serializer`.
+    # @api private
+    def recordable_object_changes
+      if @record.class.paper_trail.version_class.object_changes_col_is_json?
+        changes
+      else
+        PaperTrail.serializer.dump(changes)
+      end
+    end
+
+    # Invoked via callback when a user attempts to persist a reified
+    # `Version`.
+    def reset_timestamp_attrs_for_update_if_needed
+      return if live?
+      @record.send(:timestamp_attributes_for_update_in_model).each do |column|
+        # ActiveRecord 4.2 deprecated `reset_column!` in favor of
+        # `restore_column!`.
+        if @record.respond_to?("restore_#{column}!")
+          @record.send("restore_#{column}!")
+        else
+          @record.send("reset_#{column}!")
+        end
+      end
+    end
+
+    # Saves associations if the join table for `VersionAssociation` exists.
+    def save_associations(version)
+      return unless PaperTrail.config.track_associations?
+      save_associations_belongs_to(version)
+      save_associations_habtm(version)
+    end
+
+    def save_associations_belongs_to(version)
+      @record.class.reflect_on_all_associations(:belongs_to).each do |assoc|
+        assoc_version_args = {
+          version_id: version.id,
+          foreign_key_name: assoc.foreign_key
+        }
+
+        if assoc.options[:polymorphic]
+          associated_record = @record.send(assoc.name) if @record.send(assoc.foreign_type)
+          if associated_record && associated_record.class.paper_trail.enabled?
+            assoc_version_args[:foreign_key_id] = associated_record.id
+          end
+        elsif assoc.klass.paper_trail.enabled?
+          assoc_version_args[:foreign_key_id] = @record.send(assoc.foreign_key)
+        end
+
+        if assoc_version_args.key?(:foreign_key_id)
+          PaperTrail::VersionAssociation.create(assoc_version_args)
+        end
+      end
+    end
+
+    def save_associations_habtm(version)
+      # Use the :added and :removed keys to extrapolate the HABTM associations
+      # to before any changes were made
+      @record.class.reflect_on_all_associations(:has_and_belongs_to_many).each do |a|
+        next unless
+          @record.class.paper_trail_save_join_tables.include?(a.name) ||
+              a.klass.paper_trail.enabled?
+        assoc_version_args = {
+          version_id: version.transaction_id,
+          foreign_key_name: a.name
+        }
+        assoc_ids =
+          @record.send(a.name).to_a.map(&:id) +
+          (@record.paper_trail_habtm.try(:[], a.name).try(:[], :removed) || []) -
+          (@record.paper_trail_habtm.try(:[], a.name).try(:[], :added) || [])
+        assoc_ids.each do |id|
+          PaperTrail::VersionAssociation.create(assoc_version_args.merge(foreign_key_id: id))
+        end
+      end
+    end
+
+    # AR callback.
+    # @api private
+    def save_version?
+      if_condition = @record.paper_trail_options[:if]
+      unless_condition = @record.paper_trail_options[:unless]
+      (if_condition.blank? || if_condition.call(@record)) && !unless_condition.try(:call, @record)
+    end
+
+    def source_version
+      version
+    end
+
+    # Mimics the `touch` method from `ActiveRecord::Persistence`, but also
+    # creates a version. A version is created regardless of options such as
+    # `:on`, `:if`, or `:unless`.
+    #
+    # TODO: look into leveraging the `after_touch` callback from
+    # `ActiveRecord` to allow the regular `touch` method to generate a version
+    # as normal. May make sense to switch the `record_update` method to
+    # leverage an `after_update` callback anyways (likely for v4.0.0)
+    def touch_with_version(name = nil)
+      unless @record.persisted?
+        raise ActiveRecordError, "can not touch on a new record object"
+      end
+      attributes = @record.send :timestamp_attributes_for_update_in_model
+      attributes << name if name
+      current_time = @record.send :current_time_from_proper_timezone
+      attributes.each { |column|
+        @record.send(:write_attribute, column, current_time)
+      }
+      @record.record_update(true) unless will_record_after_update?
+      @record.save!(validate: false)
+    end
+
+    # Returns the object (not a Version) as it was at the given timestamp.
+    def version_at(timestamp, reify_options = {})
+      # Because a version stores how its object looked *before* the change,
+      # we need to look for the first version created *after* the timestamp.
+      v = versions.subsequent(timestamp, true).first
+      return v.reify(reify_options) if v
+      @record unless @record.destroyed?
+    end
+
+    # Returns the objects (not Versions) as they were between the given times.
+    def versions_between(start_time, end_time)
+      versions = send(@record.class.versions_association_name).between(start_time, end_time)
+      versions.collect { |version|
+        version_at(version.send(PaperTrail.timestamp_field))
+      }
+    end
+
+    # Executes the given method or block without creating a new version.
+    def without_versioning(method = nil)
+      paper_trail_was_enabled = enabled_for_model?
+      @record.class.paper_trail.disable
+      if method
+        if respond_to?(method)
+          public_send(method)
+        else
+          @record.send(method)
+        end
+      else
+        yield @record
+      end
+    ensure
+      @record.class.paper_trail.enable if paper_trail_was_enabled
+    end
+
+    # Temporarily overwrites the value of whodunnit and then executes the
+    # provided block.
+    def whodunnit(value)
+      raise ArgumentError, "expected to receive a block" unless block_given?
+      current_whodunnit = PaperTrail.whodunnit
+      PaperTrail.whodunnit = value
+      yield @record
+    ensure
+      PaperTrail.whodunnit = current_whodunnit
+    end
+
+    private
+
+    def add_transaction_id_to(data)
+      return unless @record.class.paper_trail.version_class.column_names.include?("transaction_id")
+      data[:transaction_id] = PaperTrail.transaction_id
+    end
+
+    def log_version_errors(version, action)
+      version.logger.warn(
+        "Unable to create version for #{action} of #{@record.class.name}##{id}: " +
+          version.errors.full_messages.join(", ")
+      )
+    end
+
+    # Returns true if `save` will cause `record_update`
+    # to be called via the `after_update` callback.
+    def will_record_after_update?
+      on = @record.paper_trail_options[:on]
+      on.nil? || on.include?(:update)
+    end
+
+    def update_transaction_id(version)
+      return unless @record.class.paper_trail.version_class.column_names.include?("transaction_id")
+      if PaperTrail.transaction? && PaperTrail.transaction_id.nil?
+        PaperTrail.transaction_id = version.id
+        version.transaction_id = version.id
+        version.save
+      end
+    end
+
+    def version
+      @record.public_send(@record.class.version_association_name)
+    end
+
+    def versions
+      @record.public_send(@record.class.versions_association_name)
+    end
+  end
+end

--- a/spec/models/boolit_spec.rb
+++ b/spec/models/boolit_spec.rb
@@ -28,7 +28,7 @@ describe Boolit, type: :model do
       end
 
       it "should still be able to be reified and persisted" do
-        expect { subject.previous_version.save! }.to_not raise_error
+        expect { subject.paper_trail.previous_version.save! }.to_not raise_error
       end
 
       context "with `nil` attributes on the live instance" do
@@ -40,7 +40,7 @@ describe Boolit, type: :model do
         after { PaperTrail.serializer = PaperTrail::Serializers::YAML }
 
         it "should not overwrite that attribute during the reification process" do
-          expect(subject.previous_version.name).to be_nil
+          expect(subject.paper_trail.previous_version.name).to be_nil
         end
       end
     end

--- a/spec/models/fluxor_spec.rb
+++ b/spec/models/fluxor_spec.rb
@@ -7,12 +7,10 @@ describe Fluxor, type: :model do
 
   describe "Methods" do
     describe "Class" do
-      subject { Fluxor }
-
-      describe "#paper_trail_enabled_for_model?" do
-        it { is_expected.to respond_to(:paper_trail_enabled_for_model?) }
-
-        it { expect(subject.paper_trail_enabled_for_model?).to be false }
+      describe ".paper_trail.enabled?" do
+        it "returns false" do
+          expect(Fluxor.paper_trail.enabled?).to eq(false)
+        end
       end
     end
   end

--- a/spec/models/gadget_spec.rb
+++ b/spec/models/gadget_spec.rb
@@ -28,10 +28,8 @@ describe Gadget, type: :model do
         describe '#changed_notably?' do
           subject { Gadget.new(created_at: Time.now) }
 
-          it { expect(subject.private_methods).to include(:changed_notably?) }
-
           context "create events" do
-            it { expect(subject.send(:changed_notably?)).to be true }
+            it { expect(subject.paper_trail.changed_notably?).to be true }
           end
 
           context "update events" do
@@ -40,12 +38,12 @@ describe Gadget, type: :model do
             context "without update timestamps" do
               it "should only acknowledge non-ignored attrs" do
                 subject.name = "Wrench"
-                expect(subject.send(:changed_notably?)).to be true
+                expect(subject.paper_trail.changed_notably?).to be true
               end
 
               it "should not acknowledge ignored attr (brand)" do
                 subject.brand = "Acme"
-                expect(subject.send(:changed_notably?)).to be false
+                expect(subject.paper_trail.changed_notably?).to be false
               end
             end
 
@@ -53,13 +51,13 @@ describe Gadget, type: :model do
               it "should only acknowledge non-ignored attrs" do
                 subject.name = "Wrench"
                 subject.updated_at = Time.now
-                expect(subject.send(:changed_notably?)).to be true
+                expect(subject.paper_trail.changed_notably?).to be true
               end
 
               it "should not acknowledge ignored attrs and timestamps only" do
                 subject.brand = "Acme"
                 subject.updated_at = Time.now
-                expect(subject.send(:changed_notably?)).to be false
+                expect(subject.paper_trail.changed_notably?).to be false
               end
             end
           end

--- a/spec/models/not_on_update_spec.rb
+++ b/spec/models/not_on_update_spec.rb
@@ -5,7 +5,7 @@ describe NotOnUpdate, type: :model do
     let!(:record) { described_class.create! }
 
     it "should create a version, regardless" do
-      expect { record.touch_with_version }.to change {
+      expect { record.paper_trail.touch_with_version }.to change {
         PaperTrail::Version.count
       }.by(+1)
     end
@@ -14,7 +14,7 @@ describe NotOnUpdate, type: :model do
       before = record.updated_at
       # Travel 1 second because MySQL lacks sub-second resolution
       Timecop.travel(1) do
-        record.touch_with_version
+        record.paper_trail.touch_with_version
       end
       expect(record.updated_at).to be > before
     end

--- a/spec/models/post_with_status_spec.rb
+++ b/spec/models/post_with_status_spec.rb
@@ -10,7 +10,7 @@ describe PostWithStatus, type: :model do
       it "should stash the enum value properly in versions" do
         post.published!
         post.archived!
-        expect(post.previous_version.published?).to be true
+        expect(post.paper_trail.previous_version.published?).to be true
       end
 
       context "storing enum object_changes" do

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -64,11 +64,11 @@ describe Widget, type: :model do
 
       subject { widget.versions.last.reify }
 
-      it { expect(subject).not_to be_live }
+      it { expect(subject.paper_trail).not_to be_live }
 
       it "should clear the `versions_association_name` virtual attribute" do
         subject.save!
-        expect(subject).to be_live
+        expect(subject.paper_trail).to be_live
       end
 
       it "corresponding version should use the widget updated_at" do
@@ -140,21 +140,21 @@ describe Widget, type: :model do
 
   describe "Methods" do
     describe "Instance", versioning: true do
-      describe '#paper_trail_originator' do
-        it { is_expected.to respond_to(:paper_trail_originator) }
-
+      describe '#paper_trail.originator' do
         describe "return value" do
           let(:orig_name) { FFaker::Name.name }
           let(:new_name) { FFaker::Name.name }
           before { PaperTrail.whodunnit = orig_name }
 
           context "accessed from live model instance" do
-            specify { expect(widget).to be_live }
+            specify { expect(widget.paper_trail).to be_live }
 
             it "should return the originator for the model at a given state" do
-              expect(widget.paper_trail_originator).to eq(orig_name)
-              widget.whodunnit(new_name) { |w| w.update_attributes(name: "Elizabeth") }
-              expect(widget.paper_trail_originator).to eq(new_name)
+              expect(widget.paper_trail.originator).to eq(orig_name)
+              widget.paper_trail.whodunnit(new_name) { |w|
+                w.update_attributes(name: "Elizabeth")
+              }
+              expect(widget.paper_trail.originator).to eq(new_name)
             end
           end
 
@@ -169,7 +169,7 @@ describe Widget, type: :model do
               let(:reified_widget) { widget.versions[1].reify }
 
               it "should return the appropriate originator" do
-                expect(reified_widget.paper_trail_originator).to eq(orig_name)
+                expect(reified_widget.paper_trail.originator).to eq(orig_name)
               end
 
               it "should not create a new model instance" do
@@ -181,7 +181,7 @@ describe Widget, type: :model do
               let(:reified_widget) { widget.versions[1].reify(dup: true) }
 
               it "should return the appropriate originator" do
-                expect(reified_widget.paper_trail_originator).to eq(orig_name)
+                expect(reified_widget.paper_trail.originator).to eq(orig_name)
               end
 
               it "should not create a new model instance" do
@@ -192,35 +192,12 @@ describe Widget, type: :model do
         end
       end
 
-      describe "#originator" do
-        subject { widget }
-
-        it { is_expected.to respond_to(:originator) }
-
-        it "should set the invoke `paper_trail_originator`" do
-          allow(::ActiveSupport::Deprecation).to receive(:warn)
-          is_expected.to receive(:paper_trail_originator)
-          subject.originator
-        end
-
-        it "should display a deprecation warning" do
-          expect(::ActiveSupport::Deprecation).to receive(:warn).
-            with(/Use paper_trail_originator instead of originator/)
-          subject.originator
-        end
-      end
-
       describe '#version_at' do
-        it { is_expected.to respond_to(:version_at) }
-
         context "Timestamp argument is AFTER object has been destroyed" do
-          before do
+          it "should return `nil`" do
             widget.update_attribute(:name, "foobar")
             widget.destroy
-          end
-
-          it "should return `nil`" do
-            expect(widget.version_at(Time.now)).to be_nil
+            expect(widget.paper_trail.version_at(Time.now)).to be_nil
           end
         end
       end
@@ -231,7 +208,7 @@ describe Widget, type: :model do
         context "no block given" do
           it "should raise an error" do
             expect {
-              widget.whodunnit("Ben")
+              widget.paper_trail.whodunnit("Ben")
             }.to raise_error(ArgumentError, "expected to receive a block")
           end
         end
@@ -246,7 +223,7 @@ describe Widget, type: :model do
           end
 
           it "should modify value of `PaperTrail.whodunnit` while executing the block" do
-            widget.whodunnit(new_name) do
+            widget.paper_trail.whodunnit(new_name) do
               expect(PaperTrail.whodunnit).to eq(new_name)
               widget.update_attributes(name: "Elizabeth")
             end
@@ -255,7 +232,9 @@ describe Widget, type: :model do
 
           context "after executing the block" do
             it "reverts value of whodunnit to previous value" do
-              widget.whodunnit(new_name) { |w| w.update_attributes(name: "Elizabeth") }
+              widget.paper_trail.whodunnit(new_name) { |w|
+                w.update_attributes(name: "Elizabeth")
+              }
               expect(PaperTrail.whodunnit).to eq(orig_name)
             end
           end
@@ -263,7 +242,7 @@ describe Widget, type: :model do
           context "error within block" do
             it "still reverts the whodunnit value to previous value" do
               expect {
-                widget.whodunnit(new_name) { raise }
+                widget.paper_trail.whodunnit(new_name) { raise }
               }.to raise_error(RuntimeError)
               expect(PaperTrail.whodunnit).to eq(orig_name)
             end
@@ -272,13 +251,11 @@ describe Widget, type: :model do
       end
 
       describe '#touch_with_version' do
-        it { is_expected.to respond_to(:touch_with_version) }
-
         it "creates a version" do
           count = widget.versions.size
           # Travel 1 second because MySQL lacks sub-second resolution
           Timecop.travel(1) do
-            widget.touch_with_version
+            widget.paper_trail.touch_with_version
           end
           expect(widget.versions.size).to eq(count + 1)
         end
@@ -287,7 +264,7 @@ describe Widget, type: :model do
           time_was = widget.updated_at
           # Travel 1 second because MySQL lacks sub-second resolution
           Timecop.travel(1) do
-            widget.touch_with_version
+            widget.paper_trail.touch_with_version
           end
           expect(widget.updated_at).to be > time_was
         end
@@ -295,33 +272,26 @@ describe Widget, type: :model do
     end
 
     describe "Class" do
-      subject { Widget }
-
-      describe "#paper_trail_enabled_for_model?" do
-        it { is_expected.to respond_to(:paper_trail_enabled_for_model?) }
-
-        it { expect(subject.paper_trail_enabled_for_model?).to be true }
-      end
-
-      describe '#paper_trail_off!' do
-        it { is_expected.to respond_to(:paper_trail_off!) }
-
-        it "should set the `paper_trail_enabled_for_model?` to `false`" do
-          expect(subject.paper_trail_enabled_for_model?).to be true
-          subject.paper_trail_off!
-          expect(subject.paper_trail_enabled_for_model?).to be false
+      describe ".paper_trail.enabled?" do
+        it "returns true" do
+          expect(Widget.paper_trail.enabled?).to eq(true)
         end
       end
 
-      describe '#paper_trail_on!' do
-        before { subject.paper_trail_off! }
+      describe ".disable" do
+        it "should set the `paper_trail.enabled?` to `false`" do
+          expect(Widget.paper_trail.enabled?).to eq(true)
+          Widget.paper_trail.disable
+          expect(Widget.paper_trail.enabled?).to eq(false)
+        end
+      end
 
-        it { is_expected.to respond_to(:paper_trail_on!) }
-
-        it "should set the `paper_trail_enabled_for_model?` to `true`" do
-          expect(subject.paper_trail_enabled_for_model?).to be false
-          subject.paper_trail_on!
-          expect(subject.paper_trail_enabled_for_model?).to be true
+      describe ".enable" do
+        it "should set the `paper_trail.enabled?` to `true`" do
+          Widget.paper_trail.disable
+          expect(Widget.paper_trail.enabled?).to eq(false)
+          Widget.paper_trail.enable
+          expect(Widget.paper_trail.enabled?).to eq(true)
         end
       end
     end

--- a/test/dummy/app/models/callback_modifier.rb
+++ b/test/dummy/app/models/callback_modifier.rb
@@ -17,27 +17,27 @@ end
 
 class BeforeDestroyModifier < CallbackModifier
   has_paper_trail on: []
-  paper_trail_on_destroy :before
+  paper_trail.on_destroy :before
 end
 
 class AfterDestroyModifier < CallbackModifier
   has_paper_trail on: []
-  paper_trail_on_destroy :after
+  paper_trail.on_destroy :after
 end
 
 class NoArgDestroyModifier < CallbackModifier
   has_paper_trail on: []
-  paper_trail_on_destroy
+  paper_trail.on_destroy
 end
 
 class UpdateModifier < CallbackModifier
   has_paper_trail on: []
-  paper_trail_on_update
+  paper_trail.on_update
 end
 
 class CreateModifier < CallbackModifier
   has_paper_trail on: []
-  paper_trail_on_create
+  paper_trail.on_create
 end
 
 class DefaultModifier < CallbackModifier

--- a/test/dummy/app/models/elephant.rb
+++ b/test/dummy/app/models/elephant.rb
@@ -1,3 +1,3 @@
 class Elephant < Animal
-  paper_trail_off!
+  paper_trail.disable
 end

--- a/test/functional/thread_safety_test.rb
+++ b/test/functional/thread_safety_test.rb
@@ -26,9 +26,9 @@ class ThreadSafetyTest < ActionController::TestCase
     enabled = nil
 
     slow_thread = Thread.new do
-      Widget.new.without_versioning do
+      Widget.new.paper_trail.without_versioning do
         sleep(0.01)
-        enabled = Widget.paper_trail_enabled_for_model?
+        enabled = Widget.paper_trail.enabled?
         sleep(0.01)
       end
       enabled
@@ -36,11 +36,11 @@ class ThreadSafetyTest < ActionController::TestCase
 
     fast_thread = Thread.new do
       sleep(0.005)
-      Widget.paper_trail_enabled_for_model?
+      Widget.paper_trail.enabled?
     end
 
     assert_not_equal slow_thread.value, fast_thread.value
-    assert Widget.paper_trail_enabled_for_model?
+    assert Widget.paper_trail.enabled?
     assert PaperTrail.enabled_for_model?(Widget)
   end
 end

--- a/test/unit/cleaner_test.rb
+++ b/test/unit/cleaner_test.rb
@@ -53,7 +53,7 @@ class PaperTrailCleanerTest < ActiveSupport::TestCase
       should "restrict the versions destroyed to those that were created on the date provided" do
         assert_equal 10, PaperTrail::Version.count
         assert_equal 4, @animal.versions.size
-        assert_equal 3, @animal.versions_between(@date, @date + 1.day).size
+        assert_equal 3, @animal.paper_trail.versions_between(@date, @date + 1.day).size
         PaperTrail.clean_versions!(date: @date)
         assert_equal 8, PaperTrail::Version.count
         assert_equal 2, @animal.versions.reload.size

--- a/test/unit/protected_attrs_test.rb
+++ b/test/unit/protected_attrs_test.rb
@@ -25,7 +25,7 @@ class ProtectedAttrsTest < ActiveSupport::TestCase
     end
 
     should "be `nil` in its previous version" do
-      assert_nil @widget.previous_version
+      assert_nil @widget.paper_trail.previous_version
     end
 
     context "which is then updated" do
@@ -36,14 +36,15 @@ class ProtectedAttrsTest < ActiveSupport::TestCase
       end
 
       should "not be `nil` in its previous version" do
-        assert_not_nil @widget.previous_version
+        assert_not_nil @widget.paper_trail.previous_version
       end
 
       should "the previous version should contain right attributes" do
         # For some reason this test seems to be broken in JRuby 1.9 mode in the
         # test env even though it works in the console. WTF?
         unless ActiveRecord::VERSION::MAJOR >= 4 && defined?(JRUBY_VERSION)
-          assert_attributes_equal @widget.previous_version.attributes, @initial_attributes
+          previous_attributes = @widget.paper_trail.previous_version.attributes
+          assert_attributes_equal previous_attributes, @initial_attributes
         end
       end
     end

--- a/test/unit/serializer_test.rb
+++ b/test/unit/serializer_test.rb
@@ -11,7 +11,7 @@ class SerializerTest < ActiveSupport::TestCase
       @fluxor = Fluxor.create name: "Some text."
 
       # this is exactly what PaperTrail serializes
-      @original_fluxor_attributes = @fluxor.send(:attributes_before_change)
+      @original_fluxor_attributes = @fluxor.paper_trail.attributes_before_change
 
       @fluxor.update_attributes name: "Some more text."
     end
@@ -41,7 +41,7 @@ class SerializerTest < ActiveSupport::TestCase
       @fluxor = Fluxor.create name: "Some text."
 
       # this is exactly what PaperTrail serializes
-      @original_fluxor_attributes = @fluxor.send(:attributes_before_change)
+      @original_fluxor_attributes = @fluxor.paper_trail.attributes_before_change
 
       @fluxor.update_attributes name: "Some more text."
     end
@@ -85,7 +85,8 @@ class SerializerTest < ActiveSupport::TestCase
 
       # this is exactly what PaperTrail serializes
       @original_fluxor_attributes = @fluxor.
-        send(:attributes_before_change).
+        paper_trail.
+        attributes_before_change.
         reject { |_k, v| v.nil? }
 
       @fluxor.update_attributes name: "Some more text."


### PR DESCRIPTION
Problem
-------

`has_paper_trail` adds too many methods to the ActiveRecord model, as described in https://github.com/airblade/paper_trail/issues/703, and others.

> If I'm counting correctly, installing the paper_trail gem adds 36 instance
> methods and 10 class methods to all of your active record models. Of those
> 46, 13 have a prefix, either "pt_" or "paper_trail_". I don't know what the
> best way to deal with this is. Ideally, we'd add far fewer methods to
> people's models. If we were able to add fewer methods to models, then I
> wouldn't mind prefixing all of them.
> https://github.com/airblade/paper_trail/issues/703

Solution
--------

Add only two methods to the AR model.

1. An instance method `#paper_trail`
2. A class method `.paper_trail`

The instance method would return a `RecordTrail` and the class method would
return a `ClassTrail`. Those names are totally up for debate.

Advantages
----------

- Plain ruby, easy to understand
- Adding new methods to e.g. the `RecordTrail` does not add any methods to
  the AR model.
- Method privacy is more strongly enforced.
- Enables isolated testing of e.g. `RecordTrail`; it can be constructed with a
  mock AR instance.

Disadvantages
-------------

- Two new classes, though they are simple.