### PR TITLE
PaperTrail.enabled now affects all threads, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,13 @@
   [#614](https://github.com/airblade/paper_trail/pull/614)
 - Added `unversioned_attributes` option to `reify`.
   [#579](https://github.com/airblade/paper_trail/pull/579)
+- Added a `config.paper_trail.enabled` option for controlling PaperTrail from the environment config.
+  [#695](https://github.com/airblade/paper_trail/pull/695)
 
 ### Fixed
 
-- None
+- Fixed deprecation warning for Active Record after_callback / after_commit
+  [#695](https://github.com/airblade/paper_trail/pull/695)
 
 ## 4.0.2 (2016-01-19)
 

--- a/README.md
+++ b/README.md
@@ -415,22 +415,20 @@ class.
 
 ### Globally
 
-On a global level you can turn PaperTrail off like this:
+On a thread global level you can turn PaperTrail off like this:
 
 ```ruby
 PaperTrail.enabled = false
 ```
 
-For example, you might want to disable PaperTrail in your Rails application's
+You might want to disable PaperTrail in your Rails application's
 test environment to speed up your tests.  This will do it (note: this gets done
 automatically for `RSpec` and `Cucumber`, please see the [Testing
 section](#testing)):
 
 ```ruby
 # in config/environments/test.rb
-config.after_initialize do
-  PaperTrail.enabled = false
-end
+config.paper_trail.enabled = false
 ```
 
 If you disable PaperTrail in your test environment but want to enable it for

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -24,7 +24,7 @@ module PaperTrail
     # PaperTrail is enabled by default.
     # @api public
     def enabled?
-      !!PaperTrail.config.enabled
+      PaperTrail.config.enabled?
     end
 
     def serialized_attributes?
@@ -168,10 +168,6 @@ unless PaperTrail.active_record_protected_attributes?
   rescue LoadError # rubocop:disable Lint/HandleExceptions
     # In case `protected_attributes` gem is not available.
   end
-end
-
-ActiveSupport.on_load(:active_record) do
-  include PaperTrail::Model
 end
 
 # Require frameworks

--- a/lib/paper_trail/frameworks/active_record.rb
+++ b/lib/paper_trail/frameworks/active_record.rb
@@ -2,3 +2,7 @@
 # since otherwise the model(s) will get loaded in via the `Rails::Engine`.
 require "paper_trail/frameworks/active_record/models/paper_trail/version_association"
 require "paper_trail/frameworks/active_record/models/paper_trail/version"
+
+ActiveSupport.on_load(:active_record) do
+  include PaperTrail::Model
+end

--- a/lib/paper_trail/frameworks/rails/engine.rb
+++ b/lib/paper_trail/frameworks/rails/engine.rb
@@ -2,6 +2,11 @@ module PaperTrail
   module Rails
     class Engine < ::Rails::Engine
       paths['app/models'] << 'lib/paper_trail/frameworks/active_record/models'
+      config.paper_trail = ActiveSupport::OrderedOptions.new
+      initializer 'paper_trail.initialisation' do |app|
+        ActiveRecord::Base.send :include, PaperTrail::Model
+        PaperTrail.enabled = app.config.paper_trail.fetch(:enabled, true)
+      end
     end
   end
 end

--- a/spec/modules/paper_trail_spec.rb
+++ b/spec/modules/paper_trail_spec.rb
@@ -5,15 +5,15 @@ describe PaperTrail, type: :module, versioning: true do
     it { is_expected.to respond_to(:config) }
 
     it "should allow for config values to be set" do
-      expect(subject.config.enabled).to eq(true)
+      expect(subject.config).to be_enabled
       subject.config.enabled = false
-      expect(subject.config.enabled).to eq(false)
+      expect(subject.config).to_not be_enabled
     end
 
     it "should accept blocks and yield the config instance" do
-      expect(subject.config.enabled).to eq(true)
+      expect(subject.config).to be_enabled
       subject.config { |c| c.enabled = false }
-      expect(subject.config.enabled).to eq(false)
+      expect(subject.config).to_not be_enabled
     end
   end
 

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -13,40 +13,5 @@ module PaperTrail
         expect { described_class.new }.to raise_error(NoMethodError)
       end
     end
-
-    describe "#enabled" do
-      context "when paper_trail_enabled is true" do
-        it "returns true" do
-          store = double
-          allow(store).to receive(:fetch).
-            with(:paper_trail_enabled, true).
-            and_return(true)
-          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(true)
-        end
-      end
-
-      context "when paper_trail_enabled is false" do
-        it "returns false" do
-          store = double
-          allow(store).to receive(:fetch).
-            with(:paper_trail_enabled, true).
-            and_return(false)
-          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(false)
-        end
-      end
-
-      context "when paper_trail_enabled is nil" do
-        it "returns true" do
-          store = double
-          allow(store).to receive(:fetch).
-            with(:paper_trail_enabled, true).
-            and_return(nil)
-          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(true)
-        end
-      end
-    end
   end
 end

--- a/test/paper_trail_test.rb
+++ b/test/paper_trail_test.rb
@@ -8,12 +8,13 @@ class PaperTrailTest < ActiveSupport::TestCase
   test 'Version Number' do
     assert PaperTrail.const_defined?(:VERSION)
   end
-  
-  test 'enabled is thread-safe' do
-    Thread.new do
-      PaperTrail.enabled = false
-    end.join
-    assert PaperTrail.enabled?
+
+  context "setting enabled" do
+    should "affect all threads" do
+      Thread.new { PaperTrail.enabled = false }.join
+      assert_equal false, PaperTrail.enabled?
+    end
+    teardown { PaperTrail.enabled = true }
   end
 
   test 'create with plain model class' do


### PR DESCRIPTION
This is a simpler alternative to https://github.com/airblade/paper_trail/pull/717 based on conversation with @seanlinsley in https://github.com/airblade/paper_trail/issues/635

As with https://github.com/airblade/paper_trail/pull/717, this expands on @Hermanverschooten's suggestion in https://github.com/airblade/paper_trail/pull/695, particularly re: the `Railtie`.
