### PR TITLE
Make PaperTrail.enabled= affect all threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking Changes
 
+- `PaperTrail.enabled=` now affects all threads
 - [#556](https://github.com/airblade/paper_trail/pull/556) /
   [#301](https://github.com/airblade/paper_trail/issues/301) -
   If you are tracking who is responsible for changes with `whodunnit`, be aware

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -8,6 +8,11 @@ module PaperTrail
     attr_writer :track_associations
 
     def initialize
+      # Variables which affect all threads, whose access is synchronized.
+      @mutex = Mutex.new
+      @enabled = true
+
+      # Variables which affect all threads, whose access is *not* synchronized.
       @timestamp_field = :created_at
       @serializer      = PaperTrail::Serializers::YAML
     end
@@ -36,12 +41,11 @@ module PaperTrail
 
     # Indicates whether PaperTrail is on or off. Default: true.
     def enabled
-      value = PaperTrail.paper_trail_store.fetch(:paper_trail_enabled, true)
-      value.nil? ? true : value
+      @mutex.synchronize { !!@enabled }
     end
 
     def enabled= enable
-      PaperTrail.paper_trail_store[:paper_trail_enabled] = enable
+      @mutex.synchronize { @enabled = enable }
     end
   end
 end

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -13,40 +13,5 @@ module PaperTrail
         expect { described_class.new }.to raise_error(NoMethodError)
       end
     end
-
-    describe "#enabled" do
-      context "when paper_trail_enabled is true" do
-        it "returns true" do
-          store = double
-          allow(store).to receive(:fetch).
-            with(:paper_trail_enabled, true).
-            and_return(true)
-          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(true)
-        end
-      end
-
-      context "when paper_trail_enabled is false" do
-        it "returns false" do
-          store = double
-          allow(store).to receive(:fetch).
-            with(:paper_trail_enabled, true).
-            and_return(false)
-          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(false)
-        end
-      end
-
-      context "when paper_trail_enabled is nil" do
-        it "returns true" do
-          store = double
-          allow(store).to receive(:fetch).
-            with(:paper_trail_enabled, true).
-            and_return(nil)
-          allow(PaperTrail).to receive(:paper_trail_store).and_return(store)
-          expect(described_class.instance.enabled).to eq(true)
-        end
-      end
-    end
   end
 end

--- a/test/paper_trail_test.rb
+++ b/test/paper_trail_test.rb
@@ -8,12 +8,13 @@ class PaperTrailTest < ActiveSupport::TestCase
   test 'Version Number' do
     assert PaperTrail.const_defined?(:VERSION)
   end
-  
-  test 'enabled is thread-safe' do
-    Thread.new do
-      PaperTrail.enabled = false
-    end.join
-    assert PaperTrail.enabled?
+
+  context "setting enabled" do
+    should "affect all threads" do
+      Thread.new { PaperTrail.enabled = false }.join
+      assert_equal false, PaperTrail.enabled?
+    end
+    teardown { PaperTrail.enabled = true }
   end
 
   test 'create with plain model class' do


### PR DESCRIPTION
- Fixes https://github.com/airblade/paper_trail/issues/635
- A subset of https://github.com/airblade/paper_trail/pull/720, this PR does not include the railtie config option
