### PR TITLE
Maps enums to database values before storing in `object_changes`

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -364,11 +364,10 @@ module PaperTrail
       # `PaperTrail.serializer`.
       # @api private
       def pt_recordable_object
-        object_attrs = object_attrs_for_paper_trail(attributes_before_change)
         if self.class.paper_trail_version_class.object_col_is_json?
-          object_attrs
+          object_attrs_for_paper_trail
         else
-          PaperTrail.serializer.dump(object_attrs)
+          PaperTrail.serializer.dump(object_attrs_for_paper_trail)
         end
       end
 
@@ -494,20 +493,14 @@ module PaperTrail
       end
 
       def attributes_before_change
-        attributes.tap do |prev|
-          enums = respond_to?(:defined_enums) ? defined_enums : {}
-          attrs = changed_attributes.select { |k, _v| self.class.column_names.include?(k) }
-          attrs.each do |attr, before|
-            before = enums[attr][before] if enums[attr]
-            prev[attr] = before
-          end
-        end
+        changed = changed_attributes.select { |k, _v| self.class.column_names.include?(k) }
+        attributes.merge(changed)
       end
 
       # Returns hash of attributes (with appropriate attributes serialized),
       # ommitting attributes to be skipped.
-      def object_attrs_for_paper_trail(attributes_hash)
-        attrs = attributes_hash.except(*paper_trail_options[:skip])
+      def object_attrs_for_paper_trail
+        attrs = attributes_before_change.except(*paper_trail_options[:skip])
         self.class.serialize_attributes_for_paper_trail!(attrs)
         attrs
       end

--- a/spec/models/post_with_status_spec.rb
+++ b/spec/models/post_with_status_spec.rb
@@ -12,6 +12,16 @@ describe PostWithStatus, type: :model do
         post.archived!
         expect(post.previous_version.published?).to be true
       end
+
+      context "storing enum object_changes" do
+        subject { post.versions.last }
+
+        it "should stash the enum value properly in versions object_changes" do
+          post.published!
+          post.archived!
+          expect(subject.changeset["status"]).to eql %w(published archived)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Keep consistency between versions with regard to `changes` and
`object_changes` and how enum columns store their values.

Before, `changes` would map the changed attributes enum columns to the database
values (integer values). This allows reifying that version to maintain the
integrity of the enum. It did not do so for `object_changes` and thus, `0`
for non-json columns, and the enum value for json columns would be stored instead.
For the non-json columns, it mapped any non-integer enum value to `0` because
during serialization that column is an `integer`.  Now this is fixed,
so that `object_changes` stores the enum mapped value.

Here is an example:

```ruby
class PostWithStatus < ActiveRecord::Base
  has_paper_trail
  enum status: { draft: 0, published: 1, archived: 2 }
end

post = PostWithStatus.new(status: :draft)
post.published!
version = post.versions.last

# Before
version.changeset #> { 'status' => ['draft', 'draft'] } (stored as [0, 0])

# After
version.changeset #> { 'status' => ['draft', 'published'] } (stored as [0, 1])
```