### PR TITLE
support for choosing association to track

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -170,6 +170,14 @@ module PaperTrail
         PaperTrail.enabled_for_model?(self)
       end
 
+      def paper_trail_enabled_for_assiociation? association
+        if paper_trail_options[:associations]
+          paper_trail_options[:associations].include? association.name
+        else
+          true
+        end
+      end
+
       def paper_trail_version_class
         @paper_trail_version_class ||= version_class_name.constantize
       end
@@ -437,6 +445,8 @@ module PaperTrail
       def save_associations(version)
         return unless PaperTrail.config.track_associations?
         self.class.reflect_on_all_associations(:belongs_to).each do |assoc|
+          next unless self.class.paper_trail_enabled_for_assiociation? assoc
+
           assoc_version_args = {
               version_id: version.id,
               foreign_key_name: assoc.foreign_key


### PR DESCRIPTION
It looks like we are saving into version_associations only when the model that is being updated has a belongs_to association.

So basically added a small check in the save_associations method. I'm not sure this is the correct way. If it is fine then I will write specs for the change.

https://github.com/airblade/paper_trail/issues/639