### PR TITLE
Allows to use default `.meta` from VersionConcern

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3,7 +3,7 @@
 
 # Offense count: 19
 Metrics/AbcSize:
-  Max: 159
+  Max: 160
 
 # Offense count: 1
 Metrics/BlockNesting:

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -82,7 +82,7 @@ module PaperTrail
           }
         end
 
-        paper_trail_options[:meta] ||= {}
+        paper_trail_options[:meta] ||= paper_trail_version_class.meta
         paper_trail_options[:save_changes] = true if paper_trail_options[:save_changes].nil?
 
         class_attribute :versions_association_name

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -56,6 +56,10 @@ module PaperTrail
         where "event <> ?", "create"
       end
 
+      def meta
+        {}
+      end
+
       # Returns versions after `obj`.
       #
       # @param obj - a `Version` or a timestamp

--- a/spec/modules/version_concern_spec.rb
+++ b/spec/modules/version_concern_spec.rb
@@ -17,6 +17,11 @@ describe PaperTrail::VersionConcern do
     expect(Bar::Document.version_class_name).to eq("Bar::Version")
   end
 
+  it "defines default meta value" do
+    expect(Foo::Version.meta).to eq({})
+    expect(Bar::Version.meta).to eq({})
+  end
+
   describe "persistence", versioning: true do
     before do
       @foo_doc = Foo::Document.create!(name: "foobar")

--- a/test/dummy/app/versions/post_version.rb
+++ b/test/dummy/app/versions/post_version.rb
@@ -1,3 +1,9 @@
 class PostVersion < PaperTrail::Version
   self.table_name = "post_versions"
+
+  attr_accessible :comments_count if ::PaperTrail.active_record_protected_attributes?
+
+  def self.meta
+    { comments_count: 42 }
+  end
 end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -65,6 +65,9 @@ class SetUpTestTables < ActiveRecord::Migration
       # Controller info columns.
       t.string :ip
       t.string :user_agent
+
+      # Default meta info columns
+      t.integer :comments_count
     end
     add_index :post_versions, [:item_type, :item_id]
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "created_at"
     t.string   "ip"
     t.string   "user_agent"
+    t.integer  "comments_count"
   end
 
   add_index "post_versions", ["item_type", "item_id"], name: "index_post_versions_on_item_type_and_item_id"

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1209,6 +1209,10 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       should "not have stored changes when object_changes column doesn't exist" do
         assert_nil @post.versions.last.changeset
       end
+
+      should "store information defined in .meta in custom version class" do
+        assert_equal(42, @post.versions.last.comments_count)
+      end
     end
   end
 


### PR DESCRIPTION
In some cases, you want to store the same information in more than one model. It can
be some shared method or kind of interface that implements method through a lot
of models. Such approach gives the ability to reduce the amount of similar code.

Example:

```ruby
class AuthorLog < PaperTrail::Version
  self.table_name = :author_logs

  def self.meta
    { :author_id => :author_id }
  end
end

class Book
  belongs_to :author
  has_paper_trail :class_name => "AuthorLog"
end

class Comment
  belongs_to :author
  has_paper_trail :class_name => "AuthorLog"
end
```

Another variant to use it is nested models

```ruby
class Book
  belongs_to :author
  has_paper_trail :class_name => "AuthorLog"
end

class Mention
  belongs_to :book
  delegate :author_id, :to => :book
  has_paper_trail :class_name => "AuthorLog"
end
```

BTW, which kind of hash syntax should I use? Currently using rocket syntax as used in README and a lot of tests