### PR TITLE
Fixes "Unknown collation: 'utf8mb4_col'" in MySQL

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3,6 +3,8 @@
 
 # Offense count: 19
 Metrics/AbcSize:
+  Exclude:
+    - 'test/dummy/db/migrate/20110208155312_set_up_test_tables.rb'
   Max: 159
 
 # Offense count: 1

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,7 +5,7 @@
 Metrics/AbcSize:
   Exclude:
     - 'test/dummy/db/migrate/20110208155312_set_up_test_tables.rb'
-  Max: 159
+  Max: 46 # Goal: 15
 
 # Offense count: 1
 Metrics/BlockNesting:

--- a/lib/generators/paper_trail/templates/create_versions.rb
+++ b/lib/generators/paper_trail/templates/create_versions.rb
@@ -58,7 +58,7 @@ class CreateVersions < ActiveRecord::Migration
   #
   def versions_table_options
     if MYSQL_ADAPTERS.include?(connection.class.name)
-      { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_col" }
+      { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" }
     else
       {}
     end

--- a/spec/generators/paper_trail/templates/create_versions_spec.rb
+++ b/spec/generators/paper_trail/templates/create_versions_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CreateVersions do
       it "uses utf8mb4_col collation" do
         migration.change
         expect(migration).to have_received(:create_table) do |_, arg2|
-          expect(arg2[:options]).to match(/COLLATE=utf8mb4_col/)
+          expect(arg2[:options]).to match(/COLLATE=utf8mb4_general_ci/)
         end
       end
     else

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -1,4 +1,13 @@
+# Keep this migration in sync with
+# `lib/generators/paper_trail/templates/create_versions.rb`
+# TODO: Is there a way to avoid duplication?
 class SetUpTestTables < ActiveRecord::Migration
+  MYSQL_ADAPTERS = [
+    "ActiveRecord::ConnectionAdapters::MysqlAdapter",
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter"
+  ].freeze
+  TEXT_BYTES = 1_073_741_823
+
   def up
     create_table :skippers, force: true do |t|
       t.string     :name
@@ -21,13 +30,13 @@ class SetUpTestTables < ActiveRecord::Migration
       t.timestamps null: true
     end
 
-    create_table :versions, force: true do |t|
+    create_table :versions, versions_table_options do |t|
       t.string   :item_type, null: false
       t.integer  :item_id,   null: false
       t.string   :event,     null: false
       t.string   :whodunnit
-      t.text     :object
-      t.text     :object_changes
+      t.text     :object, limit: TEXT_BYTES
+      t.text     :object_changes, limit: TEXT_BYTES
       t.integer  :transaction_id
       t.datetime :created_at
 
@@ -285,5 +294,15 @@ class SetUpTestTables < ActiveRecord::Migration
     remove_index :version_associations, name: "index_version_associations_on_foreign_key"
     drop_table :version_associations
     drop_table :callback_modifiers
+  end
+
+  private
+
+  def versions_table_options
+    opts = { force: true }
+    if MYSQL_ADAPTERS.include?(connection.class.name)
+      opts[:options] = "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_col"
+    end
+    opts
   end
 end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -301,7 +301,7 @@ class SetUpTestTables < ActiveRecord::Migration
   def versions_table_options
     opts = { force: true }
     if MYSQL_ADAPTERS.include?(connection.class.name)
-      opts[:options] = "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_col"
+      opts[:options] = "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
     end
     opts
   end


### PR DESCRIPTION
- Fixes "Unknown collation: 'utf8mb4_col'" in MySQL
- Updates `test/dummy/db/migrate/20110208155312_set_up_test_tables.rb` to match `lib/generators/paper_trail/templates/create_versions.rb`