### PR TITLE
Rubocop cleanup take 2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,12 @@ AllCops:
   Exclude:
     - test/dummy/db/schema.rb
 
+# Migrations often contain long up/down methods, and extracting smaller methods
+# from these is of questionable value.
+Metrics/AbcSize:
+  Exclude:
+    - 'test/dummy/db/migrate/*'
+
 Metrics/ClassLength:
   Exclude:
     - test/**/*

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,19 +18,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 16
 
-# Offense count: 11
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: prefer_alias, prefer_alias_method
-Style/Alias:
-  Exclude:
-    - 'lib/paper_trail.rb'
-    - 'lib/paper_trail/config.rb'
-    - 'lib/paper_trail/has_paper_trail.rb'
-    - 'lib/paper_trail/version_concern.rb'
-    - 'test/dummy/app/models/song.rb'
-    - 'test/unit/model_test.rb'
-
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: nested, compact
 Style/ClassAndModuleChildren:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,13 +22,6 @@ Metrics/PerceivedComplexity:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 4
-Style/MultilineTernaryOperator:
-  Exclude:
-    - 'lib/paper_trail/config.rb'
-    - 'lib/paper_trail/has_paper_trail.rb'
-    - 'lib/paper_trail/reifier.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Style/RescueModifier:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,11 +22,6 @@ Metrics/PerceivedComplexity:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 2
-Style/MultilineBlockChain:
-  Exclude:
-    - 'lib/paper_trail/version_concern.rb'
-
 # Offense count: 4
 Style/MultilineTernaryOperator:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3,9 +3,7 @@
 
 # Offense count: 19
 Metrics/AbcSize:
-  Exclude:
-    - 'test/dummy/db/migrate/20110208155312_set_up_test_tables.rb'
-  Max: 46 # Goal: 15
+  Max: 50
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,11 +21,3 @@ Metrics/PerceivedComplexity:
 # Offense count: 33
 Style/Documentation:
   Enabled: false
-
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/RescueModifier:
-  Exclude:
-    - 'lib/paper_trail/version_concern.rb'
-    - 'spec/models/version_spec.rb'
-    - 'test/dummy/app/models/person.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,12 +23,6 @@ Style/Documentation:
   Enabled: false
 
 # Offense count: 2
-Style/ModuleFunction:
-  Exclude:
-    - 'lib/paper_trail/serializers/json.rb'
-    - 'lib/paper_trail/serializers/yaml.rb'
-
-# Offense count: 2
 Style/MultilineBlockChain:
   Exclude:
     - 'lib/paper_trail/version_concern.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,12 +18,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 16
 
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: nested, compact
-Style/ClassAndModuleChildren:
-  Exclude:
-    - 'test/unit/ar_id_map_test.rb'
-
 # Offense count: 33
 Style/Documentation:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,11 +18,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 16
 
-# Offense count: 1
-Style/AccessorMethodName:
-  Exclude:
-    - 'lib/paper_trail/has_paper_trail.rb'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -154,8 +154,7 @@ module PaperTrail
       yield @config if block_given?
       @config
     end
-
-    alias_method :configure, :config
+    alias configure config
   end
 end
 

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -32,12 +32,11 @@ module PaperTrail
       )
     end
 
-    def track_associations
+    def track_associations?
       @track_associations.nil? ?
         PaperTrail::VersionAssociation.table_exists? :
         @track_associations
     end
-    alias_method :track_associations?, :track_associations
 
     # Indicates whether PaperTrail is on or off. Default: true.
     def enabled

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -33,9 +33,11 @@ module PaperTrail
     end
 
     def track_associations?
-      @track_associations.nil? ?
-        PaperTrail::VersionAssociation.table_exists? :
+      if @track_associations.nil?
+        PaperTrail::VersionAssociation.table_exists?
+      else
         @track_associations
+      end
     end
 
     # Indicates whether PaperTrail is on or off. Default: true.

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -221,9 +221,12 @@ module PaperTrail
 
       # Returns the object (not a Version) as it was most recently.
       def previous_version
-        preceding_version = source_version ?
-          source_version.previous :
-          send(self.class.versions_association_name).last
+        preceding_version =
+          if source_version
+            source_version.previous
+          else
+            send(self.class.versions_association_name).last
+          end
         preceding_version.reify if preceding_version
       end
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -252,6 +252,7 @@ module PaperTrail
 
       # Utility method for reifying. Anything executed inside the block will
       # appear like a new record.
+      # rubocop: disable Style/Alias
       def appear_as_new_record
         instance_eval {
           alias :old_new_record? :new_record?
@@ -260,6 +261,7 @@ module PaperTrail
         yield
         instance_eval { alias :new_record? :old_new_record? }
       end
+      # rubocop: enable Style/Alias
 
       # Temporarily overwrites the value of whodunnit and then executes the
       # provided block.

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -456,7 +456,7 @@ module PaperTrail
         end
       end
 
-      def set_transaction_id(version)
+      def set_transaction_id(version) # rubocop:disable Style/AccessorMethodName
         return unless self.class.paper_trail_version_class.column_names.include?("transaction_id")
         if PaperTrail.transaction? && PaperTrail.transaction_id.nil?
           PaperTrail.transaction_id = version.id

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -17,9 +17,12 @@ module PaperTrail
           unversioned_attributes: :nil
         )
 
-        attrs = version.class.object_col_is_json? ?
-          version.object :
-          PaperTrail.serializer.load(version.object)
+        attrs =
+          if version.class.object_col_is_json?
+            version.object
+          else
+            PaperTrail.serializer.load(version.object)
+          end
 
         # Normally a polymorphic belongs_to relationship allows us to get the
         # object we belong to by calling, in this case, `item`.  However this
@@ -284,9 +287,12 @@ module PaperTrail
       # table, this method would return the constant `Fruit`.
       def version_reification_class(version, attrs)
         inheritance_column_name = version.item_type.constantize.inheritance_column
-        class_name = attrs[inheritance_column_name].blank? ?
-          version.item_type :
-          attrs[inheritance_column_name]
+        class_name =
+          if attrs[inheritance_column_name].blank?
+            version.item_type
+          else
+            attrs[inheritance_column_name]
+          end
         class_name.constantize
       end
 

--- a/lib/paper_trail/serializers/json.rb
+++ b/lib/paper_trail/serializers/json.rb
@@ -3,15 +3,15 @@ require "active_support/json"
 module PaperTrail
   module Serializers
     module JSON
-      extend self # makes all instance methods become module methods as well
-
       def load(string)
         ActiveSupport::JSON.decode string
       end
+      module_function :load
 
       def dump(object)
         ActiveSupport::JSON.encode object
       end
+      module_function :dump
 
       # Returns a SQL condition to be used to match the given field and value
       # in the serialized object
@@ -30,6 +30,7 @@ module PaperTrail
           arel_field.matches("%\"#{field}\":#{json_value}%")
         end
       end
+      module_function :where_object_condition
 
       # Returns a SQL condition to be used to match the given field and value
       # in the serialized object_changes
@@ -41,6 +42,7 @@ module PaperTrail
         arel_field.matches("%\"#{field}\":[#{json_value},%").
           or(arel_field.matches("%\"#{field}\":[%,#{json_value}]%"))
       end
+      module_function :where_object_changes_condition
     end
   end
 end

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -3,21 +3,22 @@ require "yaml"
 module PaperTrail
   module Serializers
     module YAML
-      extend self # makes all instance methods become module methods as well
-
       def load(string)
         ::YAML.load string
       end
+      module_function :load
 
       def dump(object)
         ::YAML.dump object
       end
+      module_function :dump
 
       # Returns a SQL condition to be used to match the given field and value
       # in the serialized object
       def where_object_condition(arel_field, field, value)
         arel_field.matches("%\n#{field}: #{value}\n%")
       end
+      module_function :where_object_condition
 
       # Returns a SQL condition to be used to match the given field and value
       # in the serialized object_changes
@@ -38,6 +39,7 @@ module PaperTrail
         end
         arel_field.matches(m1).or(arel_field.matches(m2))
       end
+      module_function :where_object_changes_condition
 
       # Returns a symbol identifying the YAML engine. Syck was removed from
       # the ruby stdlib in ruby 2.0, but is still available as a gem.
@@ -50,6 +52,7 @@ module PaperTrail
           :syck
         end
       end
+      module_function :yaml_engine_id
     end
   end
 end

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -220,7 +220,7 @@ module PaperTrail
 
     # Returns who put the item into the state stored in this version.
     def paper_trail_originator
-      @paper_trail_originator ||= previous.whodunnit rescue nil
+      @paper_trail_originator ||= previous && previous.whodunnit
     end
 
     def originator

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -231,7 +231,7 @@ module PaperTrail
     def terminator
       @terminator ||= whodunnit
     end
-    alias_method :version_author, :terminator
+    alias version_author terminator
 
     def sibling_versions(reload = false)
       if reload || @sibling_versions.nil?

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -124,7 +124,8 @@ module PaperTrail
           arel_field = arel_table[:object]
           where_conditions = args.map { |field, value|
             PaperTrail.serializer.where_object_condition(arel_field, field, value)
-          }.reduce { |a, e| a.and(e) }
+          }
+          where_conditions = where_conditions.reduce { |a, e| a.and(e) }
           where(where_conditions)
         end
       end
@@ -150,7 +151,8 @@ module PaperTrail
           arel_field = arel_table[:object_changes]
           where_conditions = args.map { |field, value|
             PaperTrail.serializer.where_object_changes_condition(arel_field, field, value)
-          }.reduce { |a, e| a.and(e) }
+          }
+          where_conditions = where_conditions.reduce { |a, e| a.and(e) }
           where(where_conditions)
         end
       end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -43,7 +43,7 @@ describe PaperTrail::Version, type: :model do
 
   describe "Methods" do
     describe "Instance" do
-      subject { PaperTrail::Version.new(attributes) rescue PaperTrail::Version.new }
+      subject { PaperTrail::Version.new }
 
       describe '#paper_trail_originator' do
         it { is_expected.to respond_to(:paper_trail_originator) }
@@ -90,9 +90,10 @@ describe PaperTrail::Version, type: :model do
       end
 
       describe '#terminator' do
-        it { is_expected.to respond_to(:terminator) }
-
         let(:attributes) { { whodunnit: FFaker::Name.first_name } }
+        subject { PaperTrail::Version.new attributes }
+
+        it { is_expected.to respond_to(:terminator) }
 
         it "is an alias for the `whodunnit` attribute" do
           expect(subject.terminator).to eq(attributes[:whodunnit])

--- a/test/dummy/app/models/person.rb
+++ b/test/dummy/app/models/person.rb
@@ -21,7 +21,7 @@ class Person < ActiveRecord::Base
       end
 
       def load(value)
-        ::Time.find_zone!(value) rescue nil
+        ::Time.find_zone(value)
       end
     end
 

--- a/test/dummy/app/models/song.rb
+++ b/test/dummy/app/models/song.rb
@@ -23,8 +23,8 @@ class Song < ActiveRecord::Base
 
   # `alias_method_chain` is deprecated in rails 5, but we cannot use the
   # suggested replacement, `Module#prepend`, because we still support ruby 1.9.
-  alias_method :attributes_without_name, :attributes
-  alias_method :attributes, :attributes_with_name
+  alias attributes_without_name attributes
+  alias attributes attributes_with_name
 
   def changed_attributes_with_name
     if name
@@ -36,6 +36,6 @@ class Song < ActiveRecord::Base
 
   # `alias_method_chain` is deprecated in rails 5, but we cannot use the
   # suggested replacement, `Module#prepend`, because we still support ruby 1.9.
-  alias_method :changed_attributes_without_name, :changed_attributes
-  alias_method :changed_attributes, :changed_attributes_with_name
+  alias changed_attributes_without_name changed_attributes
+  alias changed_attributes changed_attributes_with_name
 end

--- a/test/unit/ar_id_map_test.rb
+++ b/test/unit/ar_id_map_test.rb
@@ -9,12 +9,14 @@ class ARIdMapTest < ActiveSupport::TestCase
 
   if defined?(ActiveRecord::IdentityMap) && ActiveRecord::IdentityMap.respond_to?(:without)
     should "not clobber the IdentityMap when reifying" do
-      module ActiveRecord::IdentityMap
-        class << self
-          alias __without without
-          def without(&block)
-            @unclobbered = true
-            __without(&block)
+      module ActiveRecord
+        module IdentityMap
+          class << self
+            alias __without without
+            def without(&block)
+              @unclobbered = true
+              __without(&block)
+            end
           end
         end
       end


### PR DESCRIPTION
WIP following #749 and #750 

Repasting my comment from #749 here:

> As for the disable comments, what do you suggest? IMO it's better to not disable checks for an entire file for known false positives, but rather to disable the individual bits where those false positives are, in order to prevent true Rubocop offenses from getting added to those files.
>
> The set_transaction_id offense is subjective - I could rename it to transaction_id= (I explained why I didn't in the commit message). But the Alias false positive is an issue with Rubocop not parsing the instance_eval blocks properly. Making Rubocop happy for that case would actually end up breaking things.

Tests should fail, since I still need to look at the failures from #749