### PR TITLE
Explicitly disable Style/AccessorMethodName for set_transaction_id

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,11 +20,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 16
 
-# Offense count: 1
-Style/AccessorMethodName:
-  Exclude:
-    - 'lib/paper_trail/has_paper_trail.rb'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -456,7 +456,7 @@ module PaperTrail
         end
       end
 
-      def set_transaction_id(version)
+      def set_transaction_id(version) # rubocop:disable Style/AccessorMethodName
         return unless self.class.paper_trail_version_class.column_names.include?("transaction_id")
         if PaperTrail.transaction? && PaperTrail.transaction_id.nil?
           PaperTrail.transaction_id = version.id


### PR DESCRIPTION
From #752.

This method is doing a lot more than just setting `transaction_id` for `self`, so to me it doesn't make sense to rename it to `transaction_id=`.

