### PR TITLE
Take private/protected methods into consideration

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -469,7 +469,7 @@ module PaperTrail
           data[k] =
             if v.respond_to?(:call)
               v.call(self)
-            elsif v.is_a?(Symbol) && respond_to?(v)
+            elsif v.is_a?(Symbol) && respond_to?(v, true)
               # If it is an attribute that is changing in an existing object,
               # be sure to grab the current version.
               if has_attribute?(v) && send("#{v}_changed?".to_sym) && data[:event] != "create"


### PR DESCRIPTION
Don't forger about private/public methods when checking if value of `:meta` hash for `has_paper_trail` method is a method
http://ruby-doc.org/core-2.3.0/Object.html#method-i-respond_to-3F