### PR TITLE
Added has_and_belongs_to_many reification

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 281
+  Max: 299
 
 # Offense count: 6
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Added
 
+- [#771](https://github.com/airblade/paper_trail/pull/771) -
+  Added support for has_and_belongs_to_many associations
 - [#741](https://github.com/airblade/paper_trail/issues/741) /
   [#681](https://github.com/airblade/paper_trail/pull/681)
   MySQL unicode support in migration generator

--- a/test/dummy/app/models/bar_habtm.rb
+++ b/test/dummy/app/models/bar_habtm.rb
@@ -1,0 +1,4 @@
+class BarHabtm < ActiveRecord::Base
+  has_and_belongs_to_many :foo_habtms
+  has_paper_trail
+end

--- a/test/dummy/app/models/foo_habtm.rb
+++ b/test/dummy/app/models/foo_habtm.rb
@@ -1,0 +1,4 @@
+class FooHabtm < ActiveRecord::Base
+  has_and_belongs_to_many :bar_habtms
+  has_paper_trail
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -249,9 +249,27 @@ class SetUpTestTables < ActiveRecord::Migration
     create_table :citations, force: true do |t|
       t.integer :quotation_id
     end
+
+    create_table :foo_habtms, force: true do |t|
+      t.string :name
+    end
+
+    create_table :bar_habtms, force: true do |t|
+      t.string :name
+    end
+
+    create_table :bar_habtms_foo_habtms, force: true, id: false do |t|
+      t.integer :foo_habtm_id
+      t.integer :bar_habtm_id
+    end
+    add_index :bar_habtms_foo_habtms, [:foo_habtm_id]
+    add_index :bar_habtms_foo_habtms, [:bar_habtm_id]
   end
 
   def down
+    drop_table :bar_habtms_foo_habtms
+    drop_table :foo_habtms
+    drop_table :bar_habtms
     drop_table :citations
     drop_table :quotations
     drop_table :animals


### PR DESCRIPTION
HABTM associations are saved as attributes with the name
association_ids as an array of the associated model IDs. Changes
made to HABTM associations are stored on the model so on save the
original associations can be stored in the serialized object. On
reification, if the has_and_belongs_to_many option is not passed,
the serialized attributes are removed such that they are not
reified. If it is passed, the association is reified but if an
associated object no longer exists, it is not added to the
CollectionProxy.