### PR TITLE
Explicit requires

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -1,14 +1,15 @@
 require "request_store"
-
-# Require files in lib/paper_trail, but not its subdirectories.
-Dir[File.join(File.dirname(__FILE__), "paper_trail", "*.rb")].each do |file|
-  require File.join("paper_trail", File.basename(file, ".rb"))
-end
-
-# Require serializers
-Dir[File.join(File.dirname(__FILE__), "paper_trail", "serializers", "*.rb")].each do |file|
-  require File.join("paper_trail", "serializers", File.basename(file, ".rb"))
-end
+require "paper_trail/attributes_serialization"
+require "paper_trail/cleaner"
+require "paper_trail/config"
+require "paper_trail/has_paper_trail"
+require "paper_trail/record_history"
+require "paper_trail/reifier"
+require "paper_trail/version_association_concern"
+require "paper_trail/version_concern"
+require "paper_trail/version_number"
+require "paper_trail/serializers/json"
+require "paper_trail/serializers/yaml"
 
 module PaperTrail
   extend PaperTrail::Cleaner


### PR DESCRIPTION
Explicit requires have three advantages:

1. Allow us to add files without them being automatically required. This may be useful for e.g. cleaner.rb
2. Enable static analysis in IDEs
3. Shave a few microseconds off of load time by eliminating a few calls to the filesystem to list directories.