### PR TITLE
Require user to specify serializer

### DIFF
--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -1,4 +1,5 @@
 require "singleton"
+require "active_support/core_ext"
 require "paper_trail/serializers/yaml"
 
 module PaperTrail
@@ -6,7 +7,18 @@ module PaperTrail
   # configuration can be found in `paper_trail.rb`, others in `controller.rb`.
   class Config
     include Singleton
-    attr_accessor :timestamp_field, :serializer, :version_limit
+
+    E_IMPLICIT_SERIALIZER = <<-EOS.strip_heredoc.freeze
+      You have not specified a serializer for PaperTrail. By default, database
+      columns like versions.object will be serialized with YAML, but in the
+      future this may change to JSON. To continue using YAML, please call
+
+          PaperTrail.serializer = PaperTrail::Serializers::YAML
+
+      If you're using Rails, an initializer would be a good place for this.
+    EOS
+
+    attr_accessor :timestamp_field, :version_limit
     attr_writer :track_associations
 
     def initialize
@@ -17,6 +29,8 @@ module PaperTrail
       # Variables which affect all threads, whose access is *not* synchronized.
       @timestamp_field = :created_at
       @serializer = PaperTrail::Serializers::YAML
+      @user_warned_about_serializer = false
+      @user_configured_serializer = false
     end
 
     def serialized_attributes
@@ -32,6 +46,23 @@ module PaperTrail
         "PaperTrail.config.serialized_attributes= is deprecated without " +
           "replacement and no longer has any effect."
       )
+    end
+
+    # Users are warned if they have not explicitly chosen a serializer,
+    # because the default may change in the future.
+    def serializer
+      unless @user_configured_serializer || @user_warned_about_serializer
+        ActiveSupport::Deprecation.warn(E_IMPLICIT_SERIALIZER)
+        @user_warned_about_serializer = true
+      end
+      @serializer
+    end
+
+    # Users will be warned if they have not explicitly chosen a serializer,
+    # so we keep track of whether this method has been called.
+    def serializer=(value)
+      @user_configured_serializer = true
+      @serializer = value
     end
 
     def track_associations?

--- a/test/dummy/config/initializers/paper_trail.rb
+++ b/test/dummy/config/initializers/paper_trail.rb
@@ -1,3 +1,5 @@
+PaperTrail.serializer = PaperTrail::Serializers::YAML
+
 # Turn on associations tracking when the test suite is run on Travis CI
 PaperTrail.config.track_associations = true if ENV["TRAVIS"]
 


### PR DESCRIPTION
Per the discussion in https://github.com/airblade/paper_trail/issues/555, if we *were* to change the default serializer (which has not been decided yet) I'd prefer to add a deprecation warning like this in one major version (currently, the next is 5) and then change the default in the version after that (e.g. 6).

@seanlinsley @batter 