### PR TITLE
Model can override the global version limit

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -179,6 +179,21 @@ module PaperTrail
       def object_changes_col_is_json?
         [:json, :jsonb].include?(columns_hash["object_changes"].try(:type))
       end
+
+      # Overrides the default +version_limit+ value per model
+      #   class Article < ActiveRecord::Base
+      #     version_limit 10
+      #   end
+      def version_limit(val)
+        @_default_version_limit = val
+      end
+
+      # This model's default +version_limit+ value
+      # returns +default_version_limit+ value
+      def default_version_limit
+        (defined?(@_default_version_limit) && @_default_version_limit) || PaperTrail.config.version_limit
+      end
+
     end
 
     # @api private
@@ -307,7 +322,7 @@ module PaperTrail
     # option, and if so enforces it.
     # @api private
     def enforce_version_limit!
-      limit = PaperTrail.config.version_limit
+      limit = default_version_limit
       return unless limit.is_a? Numeric
       previous_versions = sibling_versions.not_creates
       return unless previous_versions.size > limit


### PR DESCRIPTION
Add "version_limit 10" to your model to overide "version_limit" of PaperTrail config.