### PR TITLE
Note about PaperTrail::Version as an AR instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ Widget.paper_trail_enabled_for_model?
 widget.paper_trail_enabled_for_model?
 ```
 
-And a `PaperTrail::Version` instance has these methods:
+And a `PaperTrail::Version` instance (which is just an ordinary ActiveRecord 
+instance, with all the usual methods) adds these methods:
 
 ```ruby
 # Returns the item restored from this version.


### PR DESCRIPTION
I've noticed a bit of confusion about `PaperTrail::Version` — e.g, folks think it's more magical than it really is. Noting that it's really just a good old subclass of `AR:Base` might help.