### PR TITLE
Fix issue 738

### DIFF
--- a/lib/paper_trail/attributes_serialization.rb
+++ b/lib/paper_trail/attributes_serialization.rb
@@ -151,6 +151,7 @@ module PaperTrail
 
       serializer = CastedAttributeSerializer.new(self)
       changes.clone.each do |key, change|
+        # `change` is an Array with two elements, representing before and after.
         changes[key] = Array(change).map do |value|
           serializer.send(serialization_method, key, value)
         end

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -276,11 +276,23 @@ module PaperTrail
 
     # @api private
     def load_changeset
+      # First, deserialize the `object_changes` column.
       changes = HashWithIndifferentAccess.new(object_changes_deserialized)
+
+      # The next step is, perhaps unfortunately, called "un-serialization",
+      # and appears to be responsible for custom attribute serializers. For an
+      # example of a custom attribute serializer, see
+      # `Person::TimeZoneSerializer` in the test suite.
       item_type.constantize.unserialize_attribute_changes_for_paper_trail!(changes)
+
+      # Finally, return a Hash mapping each attribute name to
+      # a two-element array representing before and after.
       changes
     end
 
+    # If the `object_changes` column is a Postgres JSON column, then
+    # ActiveRecord will deserialize it for us. Otherwise, it's a string column
+    # and we must deserialize it ourselves.
     # @api private
     def object_changes_deserialized
       if self.class.object_changes_col_is_json?

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -283,7 +283,16 @@ module PaperTrail
       # and appears to be responsible for custom attribute serializers. For an
       # example of a custom attribute serializer, see
       # `Person::TimeZoneSerializer` in the test suite.
-      item_type.constantize.unserialize_attribute_changes_for_paper_trail!(changes)
+      #
+      # Is `item.class` good enough? Does it handle `inheritance_column`
+      # as well as `Reifier#version_reification_class`? We were using
+      # `item_type.constantize`, but that is problematic when the STI parent
+      # is not versioned. (See `Vehicle` and `Car` in the test suite).
+      #
+      # Note: `item` returns nil if `event` is "destroy".
+      unless item.nil?
+        item.class.unserialize_attribute_changes_for_paper_trail!(changes)
+      end
 
       # Finally, return a Hash mapping each attribute name to
       # a two-element array representing before and after.

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Car, type: :model do
+  it { is_expected.to be_versioned }
+
+  describe "changeset", versioning: true do
+    it "has the expected keys (see issue 738)" do
+      car = Car.create!(name: "Alice")
+      car.update_attributes(name: "Bob")
+      assert_includes car.versions.last.changeset.keys, "name"
+    end
+  end
+end

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+describe Truck, type: :model do
+  it { is_expected.to_not be_versioned }
+end

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+describe Vehicle, type: :model do
+  it { is_expected.to_not be_versioned }
+end

--- a/test/dummy/app/models/car.rb
+++ b/test/dummy/app/models/car.rb
@@ -1,0 +1,3 @@
+class Car < Vehicle
+  has_paper_trail
+end

--- a/test/dummy/app/models/truck.rb
+++ b/test/dummy/app/models/truck.rb
@@ -1,0 +1,4 @@
+class Truck < Vehicle
+  # This STI child class specifically does not call `has_paper_trail`.
+  # Of the sub-classes of `Vehicle`, only `Car` is versioned.
+end

--- a/test/dummy/app/models/vehicle.rb
+++ b/test/dummy/app/models/vehicle.rb
@@ -1,0 +1,4 @@
+class Vehicle < ActiveRecord::Base
+  # This STI parent class specifically does not call `has_paper_trail`.
+  # Of the sub-classes of `Vehicle`, only `Car` is versioned.
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -9,6 +9,13 @@ class SetUpTestTables < ActiveRecord::Migration
   TEXT_BYTES = 1_073_741_823
 
   def up
+    # Classes: Vehicle, Car, Truck
+    create_table :vehicles, force: true do |t|
+      t.string :name, null: false
+      t.string :type, null: false
+      t.timestamps null: false
+    end
+
     create_table :skippers, force: true do |t|
       t.string     :name
       t.datetime   :another_timestamp

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -211,12 +211,12 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   add_index "version_associations", ["version_id"], name: "index_version_associations_on_version_id"
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
+    t.string   "item_type",                         null: false
+    t.integer  "item_id",                           null: false
+    t.string   "event",                             null: false
     t.string   "whodunnit"
-    t.text     "object"
-    t.text     "object_changes"
+    t.text     "object",         limit: 1073741823
+    t.text     "object_changes", limit: 1073741823
     t.integer  "transaction_id"
     t.datetime "created_at"
     t.integer  "answer"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -201,6 +201,13 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "type"
   end
 
+  create_table "vehicles", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.string   "type",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "version_associations", force: :cascade do |t|
     t.integer "version_id"
     t.string  "foreign_key_name", null: false

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -433,6 +433,10 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
             assert_equal 1, @reified_widget.fluxors.length
           end
 
+          should "have nil item for last version" do
+            assert_nil(@widget.versions.last.item)
+          end
+
           should "not have changes" do
             assert_equal({}, @widget.versions.last.changeset)
           end


### PR DESCRIPTION
Fixes #738, whose root problem was a NoMethodError when an STI parent class is unversioned and thus does not respond to `unserialize_attribute_changes_for_paper_trail!`.