### PR TITLE
Use ::Kernel.warn instead of implicit receiver warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 5.0.1 (Unreleased)
+
+### Breaking Changes
+
+- None
+
+### Added
+
+- None
+
+### Fixed
+
+- [#791](https://github.com/airblade/paper_trail/issues/791) -
+  A rare issue in applications that override `warn`.
+
 ## 5.0.0 (2016-05-02)
 
 ### Breaking Changes

--- a/lib/generators/paper_trail/install_generator.rb
+++ b/lib/generators/paper_trail/install_generator.rb
@@ -40,7 +40,7 @@ module PaperTrail
     def add_paper_trail_migration(template)
       migration_dir = File.expand_path("db/migrate")
       if self.class.migration_exists?(migration_dir, template)
-        warn "Migration already exists: #{template}"
+        ::Kernel.warn "Migration already exists: #{template}"
       else
         migration_template "#{template}.rb", "db/migrate/#{template}.rb"
       end

--- a/lib/paper_trail/frameworks/rails/controller.rb
+++ b/lib/paper_trail/frameworks/rails/controller.rb
@@ -94,7 +94,7 @@ module PaperTrail
         user_present = user_for_paper_trail.present?
         whodunnit_blank = ::PaperTrail.whodunnit.blank?
         if enabled && user_present && whodunnit_blank && !@set_paper_trail_whodunnit_called
-          warn <<-EOS.strip_heredoc
+          ::Kernel.warn <<-EOS.strip_heredoc
             user_for_paper_trail is present, but whodunnit has not been set.
             PaperTrail no longer adds the set_paper_trail_whodunnit
             before_filter for you. Please add this before_filter to your


### PR DESCRIPTION
Some people override warn in their applications. Using an explicit
receiver protects against this.

[Fixes #791]