### PR TITLE
Upgrade rubocop and remove old flags

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -309,7 +309,6 @@ module PaperTrail
 
       # Utility method for reifying. Anything executed inside the block will
       # appear like a new record.
-      # rubocop: disable Style/Alias
       def appear_as_new_record
         instance_eval {
           alias :old_new_record? :new_record?
@@ -318,7 +317,6 @@ module PaperTrail
         yield
         instance_eval { alias :new_record? :old_new_record? }
       end
-      # rubocop: enable Style/Alias
 
       # Temporarily overwrites the value of whodunnit and then executes the
       # provided block.

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "generator_spec", "~> 0.9.3"
   s.add_development_dependency "database_cleaner", "~> 1.2"
   s.add_development_dependency "pry-nav", "~> 0.2.4"
-  s.add_development_dependency "rubocop", "~> 0.37.2"
+  s.add_development_dependency "rubocop", "~> 0.40.0"
   s.add_development_dependency "timecop", "~> 0.8.0"
 
   if defined?(JRUBY_VERSION)

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -121,7 +121,8 @@ describe Widget, type: :model do
     describe "sort order" do
       it "should sort by the timestamp order from the `VersionConcern`" do
         expect(widget.versions.to_sql).to eq(
-          widget.versions.reorder(PaperTrail::Version.timestamp_sort_order).to_sql)
+          widget.versions.reorder(PaperTrail::Version.timestamp_sort_order).to_sql
+        )
       end
     end
   end

--- a/spec/modules/version_number_spec.rb
+++ b/spec/modules/version_number_spec.rb
@@ -28,7 +28,8 @@ describe PaperTrail::VERSION do
 
       it "should join the numbers into a period separated string" do
         expect(subject::STRING).to eq(
-          [subject::MAJOR, subject::MINOR, subject::TINY, subject::PRE].compact.join("."))
+          [subject::MAJOR, subject::MINOR, subject::TINY, subject::PRE].compact.join(".")
+        )
       end
     end
   end

--- a/test/unit/serializers/json_test.rb
+++ b/test/unit/serializers/json_test.rb
@@ -40,7 +40,9 @@ class JSONTest < ActiveSupport::TestCase
     context "when value is a string" do
       should "construct correct WHERE query" do
         matches = PaperTrail::Serializers::JSON.where_object_condition(
-          PaperTrail::Version.arel_table[:object], :arg1, "Val 1")
+          PaperTrail::Version.arel_table[:object], :arg1,
+          "Val 1"
+        )
 
         assert matches.instance_of?(Arel::Nodes::Matches)
         if Arel::VERSION >= "6"
@@ -54,7 +56,10 @@ class JSONTest < ActiveSupport::TestCase
     context "when value is `null`" do
       should "construct correct WHERE query" do
         matches = PaperTrail::Serializers::JSON.where_object_condition(
-          PaperTrail::Version.arel_table[:object], :arg1, nil)
+          PaperTrail::Version.arel_table[:object],
+          :arg1,
+          nil
+        )
 
         assert matches.instance_of?(Arel::Nodes::Matches)
         if Arel::VERSION >= "6"
@@ -68,7 +73,10 @@ class JSONTest < ActiveSupport::TestCase
     context "when value is a number" do
       should "construct correct WHERE query" do
         grouping = PaperTrail::Serializers::JSON.where_object_condition(
-          PaperTrail::Version.arel_table[:object], :arg1, -3.5)
+          PaperTrail::Version.arel_table[:object],
+          :arg1,
+          -3.5
+        )
 
         assert grouping.instance_of?(Arel::Nodes::Grouping)
         matches = grouping.select { |v| v.instance_of?(Arel::Nodes::Matches) }

--- a/test/unit/serializers/yaml_test.rb
+++ b/test/unit/serializers/yaml_test.rb
@@ -39,7 +39,10 @@ class YamlTest < ActiveSupport::TestCase
   context "`where_object` class method" do
     should "construct correct WHERE query" do
       matches = PaperTrail::Serializers::YAML.where_object_condition(
-        PaperTrail::Version.arel_table[:object], :arg1, "Val 1")
+        PaperTrail::Version.arel_table[:object],
+        :arg1,
+        "Val 1"
+      )
       assert matches.instance_of?(Arel::Nodes::Matches)
       if Arel::VERSION >= "6"
         assert_equal matches.right.val, "%\narg1: Val 1\n%"


### PR DESCRIPTION
Rubocop released a new version this week that includes my fix for the `Style/Alias` false positives in `eval_instance` blocks: https://github.com/bbatsov/rubocop/pull/3004 🎉 

Which means I can now remove the linter comments I added in #758 👍 

I also had to change some closing parentheses to please the new Rubocop.