### PR TITLE
Fix issue 798 enum touch

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@ Metrics/CyclomaticComplexity:
   Max: 13 # Goal: 6
 
 Metrics/ModuleLength:
-  Max: 299
+  Max: 307
 
 Metrics/PerceivedComplexity:
   Max: 16 # Goal: 7

--- a/lib/paper_trail/attributes_serialization.rb
+++ b/lib/paper_trail/attributes_serialization.rb
@@ -78,7 +78,9 @@ module PaperTrail
       # `NoOpAttribute` and `SerializedAttribute`.
       class CastedAttributeSerializer < AbstractSerializer
         def serialize(attr, val)
-          val = defined_enums[attr][val] if defined_enums[attr]
+          if defined_enums[attr].present? && val.is_a?(::String)
+            val = defined_enums[attr][val]
+          end
           apply_serialization(:type_cast_for_database, attr, val)
         end
 
@@ -94,6 +96,10 @@ module PaperTrail
 
         private
 
+        # Returns a Hash that maps column names to hashes, which in turn
+        # map strings to integers. For example, the PostWithStatus model
+        # in our test suite has the following:
+        # {"status"=>{"draft"=>0, "published"=>1, "archived"=>2}}
         def defined_enums
           @defined_enums ||= (@klass.respond_to?(:defined_enums) ? @klass.defined_enums : {})
         end

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -567,8 +567,16 @@ module PaperTrail
       end
 
       def attributes_before_change
-        changed = changed_attributes.select { |k, _v| self.class.column_names.include?(k) }
-        attributes.merge(changed)
+        enums = respond_to?(:defined_enums) ? defined_enums : {}
+        attributes.tap do |prev|
+          changed = changed_attributes.select { |k, _v|
+            self.class.column_names.include?(k)
+          }
+          changed.each do |attr, before|
+            before = enums[attr][before] if enums[attr]
+            prev[attr] = before
+          end
+        end
       end
 
       # Returns hash of attributes (with appropriate attributes serialized),

--- a/spec/models/post_with_status_spec.rb
+++ b/spec/models/post_with_status_spec.rb
@@ -1,25 +1,49 @@
 require "rails_helper"
 
-# This model is in the test suite soley for the purpose of testing ActiveRecord::Enum,
-# which is available in ActiveRecord4+ only
+# This model is in the test suite solely for the purpose of testing
+# ActiveRecord::Enum, which is available in ActiveRecord4+ only
 describe PostWithStatus, type: :model do
   if defined?(ActiveRecord::Enum)
     with_versioning do
-      let(:post) { PostWithStatus.create!(status: "draft") }
-
-      it "should stash the enum value properly in versions" do
+      it "should save enum value in versions" do
+        post = PostWithStatus.create!(status: "draft") # enum 0
         post.published!
         post.archived!
-        expect(post.previous_version.published?).to be true
+        expect(post.previous_version.published?).to eq(true)
+      end
+
+      describe "#touch_with_version" do
+        it "should also save the enum value" do
+          post = PostWithStatus.create!(status: "draft") # enum 0
+          expect(post.versions.count).to eq(1)
+          post.published!
+          expect(post.versions.count).to eq(2)
+          expect(post.versions[1].object_deserialized["status"]).to eq(0) # draft
+          Timecop.travel 1.second.since # because MySQL doesn't do fractional seconds
+          post.touch_with_version
+          expect(post.versions.count).to eq(3)
+          expect(post.versions[2].object_deserialized["status"]).to eq(1) # published
+          post.archived!
+          expect(post.versions.count).to eq(4)
+          expect(post.versions[3].object_deserialized["status"]).to eq(1) # published
+          expect(post.previous_version.published?).to eq(true)
+        end
+      end
+
+      describe ".serialize_attributes_for_paper_trail!" do
+        it "preserves enums" do
+          expect(
+            described_class.serialize_attributes_for_paper_trail!("status" => 1)
+          ).to eq("status" => 1)
+        end
       end
 
       context "storing enum object_changes" do
-        subject { post.versions.last }
-
         it "should stash the enum value properly in versions object_changes" do
+          post = PostWithStatus.create!(status: "draft") # enum 0
           post.published!
           post.archived!
-          expect(subject.changeset["status"]).to eql %w(published archived)
+          expect(post.versions.last.changeset["status"]).to eql %w(published archived)
         end
       end
     end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -173,6 +173,7 @@ class SetUpTestTables < ActiveRecord::Migration
 
     create_table :post_with_statuses, force: true do |t|
       t.integer :status
+      t.timestamps
     end
 
     create_table :animals, force: true do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -162,7 +162,9 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   add_index "post_versions", ["item_type", "item_id"], name: "index_post_versions_on_item_type_and_item_id"
 
   create_table "post_with_statuses", force: :cascade do |t|
-    t.integer "status"
+    t.integer  "status"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "posts", force: :cascade do |t|


### PR DESCRIPTION
This fixes #798 in that it passes the tests, including the new test provided by Mohamed in https://github.com/airblade/paper_trail/issues/798. However, **it's a poor implementation.** The `val.is_a?(::String)` is particularly ugly. So, perhaps only useful as a starting point for discussion. 

This bug (#798) seems to have been introduced with the latest work to use AR 5's new attributes API.