### PR TITLE
Log errors when versions can't be created

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@ Metrics/CyclomaticComplexity:
   Max: 13 # Goal: 6
 
 Metrics/ModuleLength:
-  Max: 299
+  Max: 311
 
 Metrics/PerceivedComplexity:
   Max: 16 # Goal: 7

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -375,9 +375,7 @@ module PaperTrail
           if pt_record_object_changes? && changed_notably?
             data[:object_changes] = pt_recordable_object_changes
           end
-          if self.class.paper_trail_version_class.column_names.include?("transaction_id")
-            data[:transaction_id] = PaperTrail.transaction_id
-          end
+          add_transaction_id_to(data)
           version = send(self.class.versions_association_name).create! merge_metadata(data)
           update_transaction_id(version)
           save_associations(version)
@@ -397,9 +395,7 @@ module PaperTrail
           if pt_record_object_changes?
             data[:object_changes] = pt_recordable_object_changes
           end
-          if self.class.paper_trail_version_class.column_names.include?("transaction_id")
-            data[:transaction_id] = PaperTrail.transaction_id
-          end
+          add_transaction_id_to(data)
           version = send(self.class.versions_association_name).create merge_metadata(data)
           update_transaction_id(version)
           save_associations(version)
@@ -478,9 +474,7 @@ module PaperTrail
             object: pt_recordable_object,
             whodunnit: PaperTrail.whodunnit
           }
-          if self.class.paper_trail_version_class.column_names.include?("transaction_id")
-            data[:transaction_id] = PaperTrail.transaction_id
-          end
+          add_transaction_id_to(data)
           version = self.class.paper_trail_version_class.create(merge_metadata(data))
           send("#{self.class.version_association_name}=", version)
           send(self.class.versions_association_name).send :load_target
@@ -636,6 +630,11 @@ module PaperTrail
         if_condition = paper_trail_options[:if]
         unless_condition = paper_trail_options[:unless]
         (if_condition.blank? || if_condition.call(self)) && !unless_condition.try(:call, self)
+      end
+
+      def add_transaction_id_to(data)
+        return unless self.class.paper_trail_version_class.column_names.include?("transaction_id")
+        data[:transaction_id] = PaperTrail.transaction_id
       end
 
       # @api private


### PR DESCRIPTION
As discussed in #807, this PR updates `record_update` and `record_destroy` to log a warning listing all validation errors when a `Version` instance cannot be saved. It does not update `record_create` since that calls `Version.create!` instead of `Version.create` and should raise an error for any validation failures.

Due to Rubocop complaining, I have also slightly refactored `has_paper_trail.rb` to fix some of the complaints. There is still a complaint about the `InstanceMethods` module being too many lines, but I didn't see any easy way to reduce the line count of these changes without going too far off topic and into the weeds.