### PR TITLE
Replace CollectionProxy#load_target in PaperTrail::Model#record_destroy with CollectionProxy#reset

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -483,7 +483,6 @@ module PaperTrail
           end
           version = self.class.paper_trail_version_class.create(merge_metadata(data))
           send("#{self.class.version_association_name}=", version)
-          send(self.class.versions_association_name).send :load_target
           update_transaction_id(version)
           save_associations(version)
         end

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -483,6 +483,7 @@ module PaperTrail
           end
           version = self.class.paper_trail_version_class.create(merge_metadata(data))
           send("#{self.class.version_association_name}=", version)
+          send(self.class.versions_association_name).reset
           update_transaction_id(version)
           save_associations(version)
         end

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-nav", "~> 0.2.4"
   s.add_development_dependency "rubocop", "~> 0.40.0"
   s.add_development_dependency "timecop", "~> 0.8.0"
+  s.add_development_dependency "bullet", "~>5.0.0"
 
   if defined?(JRUBY_VERSION)
     s.add_development_dependency "activerecord-jdbcsqlite3-adapter", "~> 1.3.15"

--- a/test/paper_trail_test.rb
+++ b/test/paper_trail_test.rb
@@ -45,11 +45,5 @@ class PaperTrailTest < ActiveSupport::TestCase
         raise "#{association.class}#load_traget was called"
       end
     end
-
-    should 'not call PaperTrail::Version::ActiveRecord_Associations_CollectionProxy#load_target' do
-      assert_nothing_raised do
-        @widget.destroy
-      end
-    end
   end
 end

--- a/test/paper_trail_test.rb
+++ b/test/paper_trail_test.rb
@@ -36,4 +36,20 @@ class PaperTrailTest < ActiveSupport::TestCase
     versions_for_widget = PaperTrail::Version.with_item_keys("Widget", widget.id)
     assert_equal 2, versions_for_widget.length
   end
+
+  context "destroy" do
+    setup do
+      @widget = Widget.create
+      association = @widget.send(@widget.class.versions_association_name)
+      association.define_singleton_method(:load_target) do
+        raise "#{association.class}#load_traget was called"
+      end
+    end
+
+    should 'not call PaperTrail::Version::ActiveRecord_Associations_CollectionProxy#load_target' do
+      assert_nothing_raised do
+        @widget.destroy
+      end
+    end
+  end
 end


### PR DESCRIPTION
With this line, when object destroyed and version was created PaperTrail load associated version. It's bring useless query to DB.

From log:
> Started DELETE "/deploys/48" for 127.0.0.1 at 2016-05-18 12:29:33 +0500
  User Load (0.5ms)  SELECT  `users`.* FROM `users` WHERE `users`.`active` = 1 AND `users`.`deleted_at` IS NULL AND `users`.`id` = 1  ORDER BY `users`.`id` ASC LIMIT 1
Processing by DeploysController#destroy as HTML
...
  SQL (0.4ms)  UPDATE `deploys` SET `deploys`.`deleted_at` = '2016-05-18 07:29:33' WHERE `deploys`.`id` = 48
  SQL (0.4ms)  INSERT INTO `user_actions` (`item_id`, `item_type`, `event`, `object`, `whodunnit`, `created_at`) VALUES (48, 'Deploy', 'destroy', '_OBJECT_INFO_', '1', '2016-05-18 07:29:33')
**#useless request to DB
  UserAction Load (0.6ms)  SELECT `user_actions`.* FROM `user_actions` WHERE `user_actions`.`item_id` = 48 AND `user_actions`.`item_type` = 'Deploy'  ORDER BY created_at DESC, `user_actions`.`created_at` ASC, `user_actions`.`id` ASC**
   (87.9ms)  COMMIT
Redirected to http://server.dev/deploys
Completed 302 Found in 113ms (ActiveRecord: 89.9ms)

user_actions is a custom version class:
```ruby
class Deploy < ActiveRecord::Base
  has_paper_trail class_name: "UserAction",
                  versions: :user_actions,
                  version: :user_action,
                  unless: Proc.new{ PaperTrail.whodunnit.blank? },
                  skip: ( base::UNTRACKED_ATTRIBUTES || [] ) + ALWAYS_UNTRACKED
end

module PaperTrail
  class Version < ActiveRecord::Base
    PaperTrail::Rails::Engine.eager_load!
      include PaperTrail::VersionConcern
      self.abstract_class = true
  end
end

class UserAction < PaperTrail::Version
  belongs_to :user, ->{unscope(:where)}, foreign_key: :whodunnit
  default_scope ->{order('created_at DESC')}
  self.table_name = :user_actions
end
```

I'm not sure that my solution is correct, because I don't actually know why need to call#load_target, but tests was not broken.

[There](https://gist.github.com/sedx/082ccf4ff582becadae11ed939d68c10) are bug_report file, if interested.