### PR TITLE
Fix for HABTM associations when updated within 1 transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - [#789](https://github.com/airblade/paper_trail/issues/789) -
   A potentially common issue, in applications with initializers that use
   versioned models.
+- [#812](https://github.com/airblade/paper_trail/pull/812) -
+  Issue with saving HABTM associated objects using accepts_nested_attributes_for
 
 ## 5.0.0 (2016-05-02)
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -526,7 +526,7 @@ module PaperTrail
             self.class.paper_trail_save_join_tables.include?(a.name) ||
                 a.klass.paper_trail_enabled_for_model?
           assoc_version_args = {
-            version_id: version.id,
+            version_id: version.transaction_id,
             foreign_key_name: a.name
           }
           assoc_ids =

--- a/test/dummy/app/models/foo_habtm.rb
+++ b/test/dummy/app/models/foo_habtm.rb
@@ -1,4 +1,5 @@
 class FooHabtm < ActiveRecord::Base
   has_and_belongs_to_many :bar_habtms
+  accepts_nested_attributes_for :bar_habtms
   has_paper_trail
 end


### PR DESCRIPTION
When updating 2 models with a HABTM association, and using
accepts_nested_attributes_for, the association was using the
version ID instead of the transaction ID to reference the change.
This was braking the association logic and preventing proper
reification.