### PR TITLE
Ensure order of association is enforced

### DIFF
--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -124,7 +124,11 @@ module PaperTrail
           group("item_id").
           to_sql
         versions = versions_by_id(assoc.klass, version_id_subquery)
-        collection = Array.new assoc.klass.where(assoc.klass.primary_key => collection_keys)
+
+        ar_collection = assoc.klass.where(assoc.klass.primary_key => collection_keys)
+        ar_collection = ar_collection.order(assoc.options[:order]) if assoc.options[:order].present?
+
+        collection = Array.new ar_collection
         prepare_array_for_has_many(collection, options, versions)
         collection
       end


### PR DESCRIPTION
Enforces the order of has_many_through relationships when reifying.

Imagine the following models:

```ruby
class Product < ActiveRecord::Base
  has_paper_trail
  has_many :product_suppliers, dependent: :destroy
  has_many :suppliers, through: :product_suppliers, uniq: true, order: :name

  accepts_nested_attributes_for :product_suppliers, allow_destroy: true
end
```

```ruby
class ProductSupplier < ActiveRecord::Base
  has_paper_trail
  belongs_to :product, touch: true
  belongs_to :supplier
end
```

```ruby
class Supplier < ActiveRecord::Base
  has_paper_trail
  has_many :product_suppliers, dependent: :destroy
end
```

are updated in a controller like:

```ruby
Product.transaction do
  params[:product][:updated_at] = DateTime.now
  @product.update_attributes(params[:product])
end
```

when reifying with `@product.versions.last.reify(has_many: true, belongs_to: true)` the result of the suppliers relationship in the reified model will currently be ordered differently.  This resolves that and enforces the order from the HMT relationship.

Not sure exactly how to test this, maybe someone can help?