### PR TITLE
Add filename to whodunnit warning

### DIFF
--- a/lib/paper_trail/frameworks/rails/controller.rb
+++ b/lib/paper_trail/frameworks/rails/controller.rb
@@ -95,7 +95,11 @@ module PaperTrail
         user_present = user_for_paper_trail.present?
         whodunnit_blank = ::PaperTrail.whodunnit.blank?
         if user_present && whodunnit_blank && !@set_paper_trail_whodunnit_called
+          source_file_location = self.class.instance_methods(false).map { |m|
+            self.class.instance_method(m).source_location.first
+          }.uniq.first
           ::Kernel.warn <<-EOS.strip_heredoc
+            #{source_file_location}:
             user_for_paper_trail is present, but whodunnit has not been set.
             PaperTrail no longer adds the set_paper_trail_whodunnit callback for
             you. To continue recording whodunnit, please add this before_action


### PR DESCRIPTION
Fixes #825.

Taken from http://stackoverflow.com/a/10407131/1928168.

This will now output the full path to the controller file:
```
/path/to/project/app/controllers/api/v2/messages_controller.rb:
user_for_paper_trail is present, but whodunnit has not been set.
PaperTrail no longer adds the set_paper_trail_whodunnit callback for
you. To continue recording whodunnit, please add this before_action
callback to your ApplicationController . For more information,
please see https://git.io/vrTsk
```

I've chosen the full path, because as in the example above, there might be many controllers with the same name. But I'm open to suggestions! :)