### PR TITLE
Updating CI and linter config

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,8 @@ Please use our [bug report template][1].
 
 ## Development
 
+Install gems with `bundle exec appraisal install`.
+
 Testing is a little awkward because the test suite:
 
 1. Supports three major versions of rails: 3, 4, 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,13 @@ inherit_from: .rubocop_todo.yml
 # - Alphabetize cops
 # - Only include permanent config; temporary goes in .rubocop_todo.yml
 
-# We do not control `schema.rb`. Exclude it from all cops.
 AllCops:
   Exclude:
-    - test/dummy/db/schema.rb
+    - gemfiles/vendor/bundle/**/* # This dir only shows up on travis ¯\_(ツ)_/¯
+    - test/dummy/db/schema.rb # Generated, out of our control
+
+  # Set to lowest supported version
+  TargetRubyVersion: 1.9
 
 # Migrations often contain long up/down methods, and extracting smaller methods
 # from these is of questionable value.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
+cache: bundler
 rvm:
-  - 2.3.0
+  - 2.3.1
   - 1.9.3
   - jruby-19mode
 env:

--- a/Appraisals
+++ b/Appraisals
@@ -26,12 +26,13 @@ appraise "ar4" do
 end
 
 appraise "ar5" do
-  gem "activerecord", "5.0.0.rc2"
-  gem "activemodel", "5.0.0.rc2"
-  gem "actionpack", "5.0.0.rc2"
-  gem "railties", "5.0.0.rc2"
-  gem "rspec-rails", "3.5.0.beta4"
+  gem "activerecord", "~> 5.0.0"
+  gem "rspec-rails", "~> 3.5.1"
   gem 'rails-controller-testing'
-  # Sinatra stable conflicts with AR5's rack dependency
-  gem 'sinatra', github: 'sinatra/sinatra'
+
+  # Sinatra stable conflicts with AR5's rack dependency. Sinatra master requires
+  # rack-protection master. Specify exact `ref` so it doesn't break in the future.
+  # Hopefully there'll be a sinatra 2.0 release soon.
+  gem 'sinatra', github: 'sinatra/sinatra', ref: "a7483f48b0a18ba792e642a"
+  gem "rack-protection", github: "sinatra/rack-protection", ref: "7e723a74763bb83989d12"
 end

--- a/doc/bug_report_template.rb
+++ b/doc/bug_report_template.rb
@@ -18,7 +18,6 @@ require "logger"
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.logger = nil
 ActiveRecord::Schema.define do
-
   # STEP TWO: Define your tables here.
   create_table :users, force: true do |t|
     t.text :first_name, null: false

--- a/gemfiles/ar5.gemfile
+++ b/gemfiles/ar5.gemfile
@@ -2,12 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.0.0.rc2"
-gem "activemodel", "5.0.0.rc2"
-gem "actionpack", "5.0.0.rc2"
-gem "railties", "5.0.0.rc2"
-gem "rspec-rails", "3.5.0.beta4"
+gem "activerecord", "~> 5.0.0"
+gem "rspec-rails", "~> 3.5.1"
 gem "rails-controller-testing"
 gem "sinatra", :github => "sinatra/sinatra"
+gem "rack-protection", :github => "sinatra/rack-protection"
 
 gemspec :path => "../"


### PR DESCRIPTION
- ruby 2.3.1 (was 2.3.0)
- Update AR5 gemfile now that rails 5 is out
- Enable travis bundler cache. Hopefully this will speed up travis a bit.
  https://docs.travis-ci.com/user/caching/
- set TargetRubyVersion: 1.9