### PR TITLE
PaperTrail is not compatible with sinatra 2.0 yet

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -11,6 +11,7 @@ appraise "ar3" do
   gem "activerecord", "~> 3.2.22"
   gem "i18n", "~> 0.6.11"
   gem "request_store", "~> 1.1.0"
+  gem "sinatra", "~> 1.4.6"
 
   group :development, :test do
     gem 'railties', '~> 3.2.22'
@@ -23,6 +24,7 @@ end
 
 appraise "ar4" do
   gem "activerecord", "~> 4.2"
+  gem "sinatra", "~> 1.4.6"
 end
 
 appraise "ar5" do
@@ -30,9 +32,7 @@ appraise "ar5" do
   gem "rspec-rails", "~> 3.5.1"
   gem 'rails-controller-testing'
 
-  # Sinatra stable conflicts with AR5's rack dependency. Sinatra master requires
-  # rack-protection master. Specify exact `ref` so it doesn't break in the future.
-  # Hopefully there'll be a sinatra 2.0 release soon.
-  gem 'sinatra', github: 'sinatra/sinatra', ref: "a7483f48b0a18ba792e642a"
-  gem "rack-protection", github: "sinatra/rack-protection", ref: "7e723a74763bb83989d12"
+  # The AR5 version of PaperTrail is not compatible with sinatra 2 yet.
+  # Contributions welcome.
+  # gem "sinatra", "2.0.0.beta2"
 end

--- a/README.md
+++ b/README.md
@@ -1455,7 +1455,11 @@ require 'paper_trail/frameworks/rspec'
 ## 8. Sinatra
 
 To configure PaperTrail for usage with [Sinatra][12], your `Sinatra`
-app must be using `ActiveRecord` 3 or 4. It is also recommended to use the
+app must be using `ActiveRecord` 3 or 4. There is no released version of sinatra yet
+that is compatible with AR 5. We expect sinatra 2.0 to support AR 5, but it will have
+breaking changes that will require changes to PaperTrail.
+
+It is also recommended to use the
 [Sinatra ActiveRecord Extension][13] or something similar for managing your
 applications `ActiveRecord` connection in a manner similar to the way `Rails`
 does. If using the aforementioned `Sinatra ActiveRecord Extension`, steps for

--- a/gemfiles/ar3.gemfile
+++ b/gemfiles/ar3.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 3.2.22"
 gem "i18n", "~> 0.6.11"
 gem "request_store", "~> 1.1.0"
+gem "sinatra", "~> 1.4.6"
 
 group :development, :test do
   gem "railties", "~> 3.2.22"

--- a/gemfiles/ar4.gemfile
+++ b/gemfiles/ar4.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2"
+gem "sinatra", "~> 1.4.6"
 
 gemspec :path => "../"

--- a/gemfiles/ar5.gemfile
+++ b/gemfiles/ar5.gemfile
@@ -5,7 +5,5 @@ source "https://rubygems.org"
 gem "activerecord", "~> 5.0.0"
 gem "rspec-rails", "~> 3.5.1"
 gem "rails-controller-testing"
-gem "sinatra", :github => "sinatra/sinatra"
-gem "rack-protection", :github => "sinatra/rack-protection"
 
 gemspec :path => "../"

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "shoulda", "~> 3.5.0"
   s.add_development_dependency "ffaker", "~> 2.1.0"
   s.add_development_dependency "railties", [">= 3.0", "< 6.0"]
-  s.add_development_dependency "sinatra", "~> 1.4.6"
   s.add_development_dependency "rack-test", "~> 0.6.3"
   s.add_development_dependency "rspec-rails", "~> 3.5"
   s.add_development_dependency "generator_spec", "~> 0.9.3"

--- a/test/functional/modular_sinatra_test.rb
+++ b/test/functional/modular_sinatra_test.rb
@@ -1,11 +1,4 @@
-# Our ActiveRecord 5 gemfile (see `Appraisals`) must use `rack 2.0.0.alpha`
-# which renames several files that sinatra 1 depended on. Until there is
-# a released version of sinatra that supports `rack 2.0.0.alpha`, we
-# must exclude sinatra from our test suite. This is done in two files:
-#
-# - test/functional/sinatra_test.rb
-# - test/functional/modular_sinatra_test.rb
-#
+# PaperTrail is not compatible with sinatra 2 yet. Contributions welcome.
 if Gem::Version.new(Rack.release) < Gem::Version.new("2.0.0.alpha")
   require "test_helper"
   require "sinatra/base"

--- a/test/functional/sinatra_test.rb
+++ b/test/functional/sinatra_test.rb
@@ -1,11 +1,4 @@
-# Our ActiveRecord 5 gemfile (see `Appraisals`) must use `rack 2.0.0.alpha`
-# which renames several files that sinatra 1 depended on. Until there is
-# a released version of sinatra that supports `rack 2.0.0.alpha`, we
-# must exclude sinatra from our test suite. This is done in two files:
-#
-# - test/functional/sinatra_test.rb
-# - test/functional/modular_sinatra_test.rb
-#
+# PaperTrail is not compatible with sinatra 2 yet. Contributions welcome.
 if Gem::Version.new(Rack.release) < Gem::Version.new("2.0.0.alpha")
   require "test_helper"
   # require 'sinatra/main'


### PR DESCRIPTION
In the meantime, this commit fixes our CI.

See https://github.com/sinatra/rack-protection/issues/117