### PR TITLE
Generate an initializer with `track_associations`,  improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ has been destroyed.
 - [7. Testing](#7-testing)
 - [8. Sinatra](#8-sinatra)
 - [9. Configuration](#9-configuration)
-- [10. Upgrading](#10-upgrading)
 
 ## 1. Introduction
 
@@ -1540,22 +1539,6 @@ Additionally, the following options exist on `PaperTrail` itself:
 | option                  | default         | more information |
 | ----------------------- | --------------- | ---------------- |
 | `enabled`               | `true`          | [2.d. Turning PaperTrail Off](#2d-turning-papertrail-off) |
-
-## 10. Upgrading
-
-Most important: **please review the [CHANGELOG](CHANGELOG.md) and pay careful attention to any breaking changes.**
-
-Additionally, the following sections may be helpful:
-
-### Tracking Associations
-
-Version 5 introduced a deprecation warning if you do not explicitly set a value for `PaperTrail.config.track_associations`.
-
-If you are upgrading from version 4 and are *already* tracking associations, make sure you set `PaperTrail.config.track_associations = true` (see [configuration](#9-configuration))
-
-If you are upgrading from version 3 or 4 and *want* to track associations, see [4.b. Associations](#4b-associations).
-
-If you are upgrading from version 3 or 4 and do *not* want to track associations, make sure you set `PaperTrail.config.track_associations = false` (see [configuration](#9-configuration))
 
 ## Articles
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ has been destroyed.
   - [1.b. Installation](#1b-installation)
   - [1.c. Basic Usage](#1c-basic-usage)
   - [1.d. API Summary](#1d-api-summary)
+  - [1.e. Configuration](#1e-configuration)
 - [2. Limiting What is Versioned, and When](#2-limiting-what-is-versioned-and-when)
   - [2.a. Choosing Lifecycle Events To Monitor](#2a-choosing-lifecycle-events-to-monitor)
   - [2.b. Choosing When To Save New Versions](#2b-choosing-when-to-save-new-versions)
@@ -49,7 +50,6 @@ has been destroyed.
   - [6.b. Custom Serializer](#6b-custom-serializer)
 - [7. Testing](#7-testing)
 - [8. Sinatra](#8-sinatra)
-- [9. Configuration](#9-configuration)
 
 ## 1. Introduction
 
@@ -253,6 +253,18 @@ user_for_paper_trail
 # PaperTrail to store alongside any changes that occur.
 info_for_paper_trail
 ```
+
+### 1.e. Configuration
+
+Many aspects of PaperTrail are configurable for individual models; typically
+this is achieved by passing options to the `has_paper_trail` method within
+a given model.
+
+Some aspects of PaperTrail are configured globally for all models. These
+settings are assigned directly on the `PaperTrail.config` object.
+A common place to put these settings is in a Rails initializer file
+such as `config/initializers/paper_trail.rb` or in an environment-specific
+configuration file such as `config/environments/test.rb`.
 
 ## 2. Limiting What is Versioned, and When
 
@@ -756,19 +768,18 @@ string, please try the [paper_trail-globalid][37] gem.
 below.
 
 PaperTrail can restore three types of associations: Has-One, Has-Many, and
-Has-Many-Through. In order to do this, you will need two things:
+Has-Many-Through. In order to do this, you will need to do two things:
 
-  1. A `version_associations` table
-  2. Set `PaperTrail.config.track_associations = true`.
+1. Create a `version_associations` table
+2. Set `PaperTrail.config.track_associations = true` (e.g. in an initializer)
 
-This will be done for you automatically if you install PaperTrail with the
+Both will be done for you automatically if you install PaperTrail with the
 `--with_associations` option
 (e.g. `rails generate paper_trail:install --with-associations`)
 
 If you want to add this functionality after the initial installation, you will
 need to create the `version_associations` table manually, and you will need to
-ensure that `PaperTrail.config.track_associations = true`
-(see [configuration](#9-configuration))
+ensure that `PaperTrail.config.track_associations = true` is set.
 
 PaperTrail will store in the `version_associations` table additional information
 to correlate versions of the association and versions of the model when the
@@ -1515,30 +1526,6 @@ class BlehApp < Sinatra::Base
   register PaperTrail::Sinatra
 end
 ```
-
-## 9. Configuration
-
-PaperTrail has some app-wide configuration options. You typically
-configure these options in a Rails initializer or an environment
-configuration file.
-
-```ruby
-# config/initializers/paper_trail.rb
-PaperTrail.config.track_associations = false
-```
-
-The following options exist on `PaperTrail.config`:
-
-| option                  | default           | more information |
-| ----------------------- | ----------------- | ---------------- |
-| `track_assocations`     | `false`           | [4.b. Associations](#4b-associations)
-| `version_limit`         | `nil` (no limit)  | [2.e. Limiting the Number of Versions Created](#2e-limiting-the-number-of-versions-created)
-
-Additionally, the following options exist on `PaperTrail` itself:
-
-| option                  | default         | more information |
-| ----------------------- | --------------- | ---------------- |
-| `enabled`               | `true`          | [2.d. Turning PaperTrail Off](#2d-turning-papertrail-off) |
 
 ## Articles
 

--- a/lib/generators/paper_trail/install_generator.rb
+++ b/lib/generators/paper_trail/install_generator.rb
@@ -20,7 +20,8 @@ module PaperTrail
       desc: "Store transactional IDs to support association restoration"
     )
 
-    desc "Generates (but does not run) a migration to add a versions table."
+    desc "Generates (but does not run) a migration to add a versions table." \
+         "  Also generates an initializer file for configuring PaperTrail"
 
     def create_migration_file
       add_paper_trail_migration("create_versions")
@@ -29,6 +30,13 @@ module PaperTrail
         add_paper_trail_migration("create_version_associations")
         add_paper_trail_migration("add_transaction_id_column_to_versions")
       end
+    end
+
+    def create_initializer
+      create_file(
+        "config/initializers/paper_trail.rb",
+        "PaperTrail.config.track_associations = #{!!options.with_associations?}"
+      )
     end
 
     def self.next_migration_number(dirname)


### PR DESCRIPTION
Closes #830

This PR updates the install generator to create an initializer:

```ruby
# config/initializers/paper_trail.rb
PaperTrail.config.track_associations = false
```

If `--with-associations` is used, the generator sets the value to `true` instead of `false`.

Also included in this PR is documentation [suggested here](https://github.com/airblade/paper_trail/issues/830#issuecomment-230179211) as well as other documentation improvements focusing on the `track_associations` configuration, configuration in general, and basic upgrade information regarding tracking associations.

Some of this might be overkill, but updating from v3 to v5, I was a little surprised to see a deprecation warning for a feature I wasn't even using, and further surprised when I didn't see mention of an initializer in the docs (or an aggregated configuration section at all). 

Please feel free to remove anything you feel is overkill, edit, or suggest improvements. Thanks!