### PR TITLE
Use `before_action` instead of `before_filter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,8 +106,8 @@
 - [#556](https://github.com/airblade/paper_trail/pull/556) /
   [#301](https://github.com/airblade/paper_trail/issues/301) -
   If you are tracking who is responsible for changes with `whodunnit`, be aware
-  that PaperTrail no longer adds the `set_paper_trail_whodunnit` before_filter
-  for you. Please add this before_filter to your ApplicationController to
+  that PaperTrail no longer adds the `set_paper_trail_whodunnit` before_action
+  for you. Please add this before_action to your ApplicationController to
   continue recording whodunnit. See the readme for an example.
 - [#683](https://github.com/airblade/paper_trail/pull/683) /
   [#682](https://github.com/airblade/paper_trail/issues/682) -

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ by adding a controller callback.
 
     ```ruby
     class ApplicationController
-      before_filter :set_paper_trail_whodunnit
+      before_action :set_paper_trail_whodunnit
     end
     ```
 
@@ -691,12 +691,12 @@ widget.versions.last.whodunnit              # Andy Stewart
 ```
 
 If your controller has a `current_user` method, PaperTrail provides a
-`before_filter` that will assign `current_user.id` to `PaperTrail.whodunnit`.
-You can add this `before_filter` to your `ApplicationController`.
+`before_action` that will assign `current_user.id` to `PaperTrail.whodunnit`.
+You can add this `before_action` to your `ApplicationController`.
 
 ```ruby
 class ApplicationController
-  before_filter :set_paper_trail_whodunnit
+  before_action :set_paper_trail_whodunnit
 end
 ```
 

--- a/doc/warning_about_not_setting_whodunnit.md
+++ b/doc/warning_about_not_setting_whodunnit.md
@@ -3,12 +3,12 @@
 After upgrading to PaperTrail 5, you see this warning:
 
 > user_for_paper_trail is present, but whodunnit has not been set. PaperTrail no
-> longer adds the set_paper_trail_whodunnit before_filter for you. Please add this
-> before_filter to your ApplicationController to continue recording whodunnit.
+> longer adds the set_paper_trail_whodunnit before_action for you. Please add this
+> before_action to your ApplicationController to continue recording whodunnit.
 
 ## You want to track whodunnit
 
-Add the set_paper_trail_whodunnit before_filter to your ApplicationController.
+Add the set_paper_trail_whodunnit before_action to your ApplicationController.
 See the PaperTrail readme for an example (https://git.io/vrsbt).
 
 ## You don't want to track whodunnit


### PR DESCRIPTION
Warning message use `before_action` instead of `before_filter` since https://github.com/airblade/paper_trail/commit/3ce2b34b98345cad736f64a3a5e1374f40adc652 .
So I think documentations should use `before_action` too.