### PR TITLE
Tests: remove sacrificial_column

### DIFF
--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -32,7 +32,6 @@ class SetUpTestTables < ActiveRecord::Migration
       t.time      :a_time
       t.date      :a_date
       t.boolean   :a_boolean
-      t.string    :sacrificial_column
       t.string    :type
       t.timestamps null: true
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -250,12 +250,11 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.text     "a_text"
     t.integer  "an_integer"
     t.float    "a_float"
-    t.decimal  "a_decimal",          precision: 6, scale: 4
+    t.decimal  "a_decimal",  precision: 6, scale: 4
     t.datetime "a_datetime"
     t.time     "a_time"
     t.date     "a_date"
     t.boolean  "a_boolean"
-    t.string   "sacrificial_column"
     t.string   "type"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,7 +95,6 @@ end
 def change_schema
   ActiveRecord::Migration.verbose = false
   ActiveRecord::Schema.define do
-    remove_column :widgets, :sacrificial_column
     add_column :versions, :custom_created_at, :datetime
   end
   ActiveRecord::Migration.verbose = true
@@ -121,7 +120,6 @@ end
 def restore_schema
   ActiveRecord::Migration.verbose = false
   ActiveRecord::Schema.define do
-    add_column :widgets, :sacrificial_column, :string
     remove_column :versions, :custom_created_at
   end
   ActiveRecord::Migration.verbose = true

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -520,7 +520,6 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         change_schema
         Widget.connection.schema_cache.clear!
         Widget.reset_column_information
-        assert_raise(NoMethodError) { Widget.new.sacrificial_column }
         @last = @widget.versions.last
       end
 


### PR DESCRIPTION
This column has been in the test database since Andy's first commit in
2009, but it's purpose is unclear. There was only one test that mentioned
it, but the test involved only AR methods, nothing from PT. We don't
need to test AR, they've got plenty of their own tests.