### PR TITLE
Need a helper method to help locate all dependent versions.

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -129,13 +129,12 @@ module PaperTrail
 
       def dependent_versions(class_name, foreign_key)
         children = []
-        PaperTrail::Version.where(:item_type=>class_name).where("created_at >= ?", self.created_at).each do |m|
+        PaperTrail::Version.where(item_type: class_name).where("created_at >= ?", created_at).each do |m|
           child = m.reify
-          if child.present?
-            # check the child's belongs_to to make sure it is a child
-            if child.send(foreign_key) == self.id
-              children << child
-            end
+          next unless child.present?
+          # check the child's belongs_to to make sure it is a child
+          if child.send(foreign_key) == id
+            children << child
           end
         end
         children

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -127,18 +127,6 @@ module PaperTrail
         ::PaperTrail::RecordTrail.new(self)
       end
 
-      def dependent_versions(class_name, foreign_key)
-        children = []
-        versions = PaperTrail::Version.where(item_type: class_name)
-        versions.where("created_at >= ?", created_at).each do |m|
-          child = m.reify
-          next unless child.present?
-          # check the child's belongs_to to make sure it is a child
-          children << child if child.try(foreign_key) == id
-        end
-        children
-      end
-
       # @deprecated
       def live?
         self.class.paper_trail_deprecate "live?"

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -129,13 +129,12 @@ module PaperTrail
 
       def dependent_versions(class_name, foreign_key)
         children = []
-        PaperTrail::Version.where(item_type: class_name).where("created_at >= ?", created_at).each do |m|
+        versions = PaperTrail::Version.where(item_type: class_name)
+        versions.where("created_at >= ?", created_at).each do |m|
           child = m.reify
           next unless child.present?
           # check the child's belongs_to to make sure it is a child
-          if child.send(foreign_key) == id
-            children << child
-          end
+          children << child if child.try(foreign_key) == id
         end
         children
       end

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -127,6 +127,20 @@ module PaperTrail
         ::PaperTrail::RecordTrail.new(self)
       end
 
+      def dependent_versions(class_name, foreign_key)
+        children = []
+        PaperTrail::Version.where(:item_type=>class_name).where("created_at >= ?", self.created_at).each do |m|
+          child = m.reify
+          if child.present?
+            # check the child's belongs_to to make sure it is a child
+            if child.send(foreign_key) == self.id
+              children << child
+            end
+          end
+        end
+        children
+      end
+
       # @deprecated
       def live?
         self.class.paper_trail_deprecate "live?"

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -407,6 +407,13 @@ module PaperTrail
       PaperTrail.whodunnit = current_whodunnit
     end
 
+    def dependent_versions(class_name, foreign_key)
+     PaperTrail::Version.where(item_type: class_name).
+      subsequent(@record.created_at, true).map(&:reify).compact.select do |obj|
+        obj.try(foreign_key) == @record.id
+      end
+    end
+    
     private
 
     def add_transaction_id_to(data)

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -408,12 +408,12 @@ module PaperTrail
     end
 
     def dependent_versions(class_name, foreign_key)
-     PaperTrail::Version.where(item_type: class_name).
+      PaperTrail::Version.where(item_type: class_name).
       subsequent(@record.created_at, true).map(&:reify).compact.select do |obj|
         obj.try(foreign_key) == @record.id
       end
     end
-    
+
     private
 
     def add_transaction_id_to(data)


### PR DESCRIPTION
My "dependent_versions" function allows you to collect versions of associated objects from the parent object.  

Usage:
foo = Foo.first
reified_children = foo.dependent_versions(Bar, :foo_id)

The return value can be used to view all children of the parent even if the associated child has been destroyed.

If you would like to merge this, I would be happy to update the README.md file with details.  Unfortunately, I could use help writing a spec/test for this function in your framework. 