### PR TITLE
issue with primary key other than `id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
+- [#868](https://github.com/airblade/paper_trail/pull/868)
+  Fix usage of find_by_id when primary key is not id, affecting reifying certain records.
+
 ## 5.2.2 (2016-09-08)
 
 ### Breaking Changes

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -31,7 +31,8 @@ module PaperTrail
           klass = version_reification_class(version, attrs)
           # The `dup` option always returns a new object, otherwise we should
           # attempt to look for the item outside of default scope(s).
-          if options[:dup] || (item_found = klass.unscoped.find_by_id(version.item_id)).nil?
+          find_cond = { klass.primary_key => version.item_id }
+          if options[:dup] || (item_found = klass.unscoped.where(find_cond).first).nil?
             model = klass.new
           elsif options[:unversioned_attributes] == :nil
             model = item_found

--- a/spec/models/custom_primary_key_record_spec.rb
+++ b/spec/models/custom_primary_key_record_spec.rb
@@ -11,6 +11,8 @@ describe CustomPrimaryKeyRecord, type: :model do
       expect(version).to be_a(CustomPrimaryKeyRecordVersion)
       version_from_db = CustomPrimaryKeyRecordVersion.last
       expect(version_from_db.reify).to be_a(CustomPrimaryKeyRecord)
+      custom_primary_key_record.destroy
+      expect(CustomPrimaryKeyRecordVersion.last.reify).to be_a(CustomPrimaryKeyRecord)
     end
   end
 end

--- a/spec/models/custom_primary_key_record_spec.rb
+++ b/spec/models/custom_primary_key_record_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe CustomPrimaryKeyRecord, type: :model do
+  it { is_expected.to be_versioned }
+
+  describe "#versions" do
+    it "returns instances of CustomPrimaryKeyRecordVersion", versioning: true do
+      custom_primary_key_record = described_class.create!
+      custom_primary_key_record.update_attributes!(name: "bob")
+      version = custom_primary_key_record.versions.last
+      expect(version).to be_a(CustomPrimaryKeyRecordVersion)
+      version_from_db = CustomPrimaryKeyRecordVersion.last
+      expect(version_from_db.reify).to be_a(CustomPrimaryKeyRecord)
+    end
+  end
+end

--- a/test/dummy/app/models/custom_primary_key_record.rb
+++ b/test/dummy/app/models/custom_primary_key_record.rb
@@ -1,0 +1,13 @@
+require "securerandom"
+class CustomPrimaryKeyRecord < ActiveRecord::Base
+  self.primary_key = :uuid
+
+  has_paper_trail class_name: "CustomPrimaryKeyRecordVersion"
+  # this unusual default_scope is to test the case of the Version#item association
+  # not returning the item due to unmatched default_scope on the model.
+  default_scope -> { where(name: "custom_primary_key_record") }
+
+  before_create do
+    self.uuid ||= SecureRandom.uuid
+  end
+end

--- a/test/dummy/app/versions/custom_primary_key_record_version.rb
+++ b/test/dummy/app/versions/custom_primary_key_record_version.rb
@@ -1,0 +1,3 @@
+class CustomPrimaryKeyRecordVersion < PaperTrail::Version
+  self.table_name = "custom_primary_key_record_versions"
+end

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -271,6 +271,23 @@ class SetUpTestTables < ActiveRecord::Migration
     end
     add_index :bar_habtms_foo_habtms, [:foo_habtm_id]
     add_index :bar_habtms_foo_habtms, [:bar_habtm_id]
+
+    # custom_primary_key_records use a uuid column (string)
+    create_table :custom_primary_key_records, primary_key: "uuid", id: :string, force: true do |t|
+      t.string :name
+      t.timestamps null: true
+    end
+
+    # and custom_primary_key_record_versions stores the uuid in item_id, a string
+    create_table :custom_primary_key_record_versions, force: true do |t|
+      t.string   :item_type, null: false
+      t.string   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object
+      t.datetime :created_at
+    end
+    add_index :custom_primary_key_record_versions, [:item_type, :item_id]
   end
 
   def down

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -287,7 +287,7 @@ class SetUpTestTables < ActiveRecord::Migration
       t.text     :object
       t.datetime :created_at
     end
-    add_index :custom_primary_key_record_versions, [:item_type, :item_id]
+    add_index :custom_primary_key_record_versions, [:item_type, :item_id], name: "idx_cust_pk_item"
   end
 
   def down

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -273,7 +273,8 @@ class SetUpTestTables < ActiveRecord::Migration
     add_index :bar_habtms_foo_habtms, [:bar_habtm_id]
 
     # custom_primary_key_records use a uuid column (string)
-    create_table :custom_primary_key_records, primary_key: "uuid", id: :string, force: true do |t|
+    create_table :custom_primary_key_records, id: false, force: true do |t|
+      t.column :uuid, :string, primary_key: true
       t.string :name
       t.timestamps null: true
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -80,6 +80,24 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.integer "quotation_id"
   end
 
+  create_table "custom_primary_key_record_versions", force: :cascade do |t|
+    t.string   "item_type",  null: false
+    t.string   "item_id",    null: false
+    t.string   "event",      null: false
+    t.string   "whodunnit"
+    t.text     "object"
+    t.datetime "created_at"
+  end
+
+  add_index "custom_primary_key_record_versions", ["item_type", "item_id"], name: "idx_cust_pk_item"
+
+  create_table "custom_primary_key_records", id: false, force: :cascade do |t|
+    t.string   "uuid"
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "customers", force: :cascade do |t|
     t.string "name"
   end


### PR DESCRIPTION
attempting to reify records with a primary key other than `id` can run into an error `NoMethodError: undefined method 'find_by_id'` when the Version#item association does not exist, due to either not being in the default scope, or the record no longer existing.

this fixes use of `find_by_id` to instead use whatever the primary key is. 

I tried to heed rubocop warnings and follow existing testing conventions, but that may need some changes. I had some trouble testing the full matrix, will see what travis does with this PR.