### PR TITLE
Drop support for ruby <= 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.3.1
-  - 1.9.3
-  - jruby-19mode
+  - 2.1.10
 env:
   global:
     - TRAVIS=true
@@ -33,9 +32,7 @@ matrix:
   fast_finish: true
   exclude:
     - gemfile: gemfiles/ar_5.0.gemfile
-      rvm: 1.9.3
-    - gemfile: gemfiles/ar_5.0.gemfile
-      rvm: jruby-19mode
+      rvm: 2.1.10
   allow_failures:
     - gemfile: gemfiles/ar_master.gemfile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Breaking Changes
 
-- None
+- Drop support for ruby 1.9.3, whose EOL was 2015-02-23
+- Drop support for ruby 2.0.0, whose EOL was 2016-02-24
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ has been destroyed.
 
 | paper_trail    | branch     | tags   | ruby     | activerecord  |
 | -------------- | ---------- | ------ | -------- | ------------- |
-| 6              | master     | v6.x   | >= 1.9.3 | >= 4.0, < 6   |
+| unreleased     | master     |        | >= 2.1.0 | >= 4.0, < 6   |
+| 6              | 6-stable   | v6.x   | >= 1.9.3 | >= 4.0, < 6   |
 | 5              | 5-stable   | v5.x   | >= 1.9.3 | >= 3.0, < 5.1 |
 | 4              | 4-stable   | v4.x   | >= 1.8.7 | >= 3.0, < 5.1 |
 | 3              | 3.0-stable | v3.x   | >= 1.8.7 | >= 3.0, < 5   |

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -3,7 +3,7 @@ require "paper_trail/version_number"
 
 Gem::Specification.new do |s|
   s.name = "paper_trail"
-  s.version = PaperTrail::VERSION::STRING.dup # The `dup` is for ruby 1.9.3
+  s.version = PaperTrail::VERSION::STRING
   s.platform = Gem::Platform::RUBY
   s.summary = "Track changes to your models."
   s.description = <<-EOS
@@ -22,7 +22,7 @@ has been destroyed.
   s.require_paths = ["lib"]
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.1.0"
 
   # Rails does not follow semver, makes breaking changes in minor versions.
   s.add_dependency "activerecord", [">= 4.0", "< 5.2"]
@@ -41,37 +41,9 @@ has been destroyed.
   s.add_development_dependency "generator_spec", "~> 0.9.3"
   s.add_development_dependency "database_cleaner", "~> 1.2"
   s.add_development_dependency "pry-nav", "~> 0.2.4"
-
-  # We cannot upgrade rubocop until we drop support for ruby 1.9.3.
-  # Rubocop 0.42 requires ruby >= 2.0. We could add a conditional, as we do
-  # below for rack and pg, but that means our config files (e.g. `.rubocop.yml`
-  # would have to simultaneously be valid in two different versions of rubocop.
-  # That is currently possible, but probably won't be in the future, and is
-  # not worth the effort.) Because of pain points like this, I think we'll
-  # have to drop support for ruby 1.9.3 soon.
   s.add_development_dependency "rubocop", "~> 0.41.1"
-
   s.add_development_dependency "timecop", "~> 0.8.0"
-
-  if ::Gem.ruby_version < ::Gem::Version.new("2.0.0")
-    s.add_development_dependency "rack", "< 2"
-  end
-
-  if defined?(JRUBY_VERSION)
-    s.add_development_dependency "activerecord-jdbcsqlite3-adapter", "~> 1.3.15"
-    s.add_development_dependency "activerecord-jdbcpostgresql-adapter", "~> 1.3.15"
-    s.add_development_dependency "activerecord-jdbcmysql-adapter", "~> 1.3.15"
-  else
-    s.add_development_dependency "sqlite3", "~> 1.2"
-
-    # pg 0.19 requires ruby >= 2.0.0
-    if ::Gem.ruby_version >= ::Gem::Version.new("2.0.0")
-      s.add_development_dependency "pg", "~> 0.19.0"
-    else
-      s.add_development_dependency "pg", [">= 0.17", "< 0.19"]
-    end
-
-    # activerecord >= 4.2.5 may use mysql2 >= 0.4
-    s.add_development_dependency "mysql2", "~> 0.4.2"
-  end
+  s.add_development_dependency "sqlite3", "~> 1.2"
+  s.add_development_dependency "pg", "~> 0.19.0"
+  s.add_development_dependency "mysql2", "~> 0.4.2"
 end


### PR DESCRIPTION
According to the [2016 Rails Hosting Survey](http://rails-hosting.com/2016/index.html), usage of ruby 1.9.3 has dropped to around 10%, with much of this drop occuring in 2016.

> Usage of 1.9.3 dropped by 16% [since the 2015 survey] and adoption of Ruby 2.2 and 2.3 jumped up to 27% each.

The 2016 survey had 1,417 respondents.

IMO it is acceptable for development of a new major version of to continue, while the 10% of the community using 1.9.3 continues to use the previous version.

Other major gems which have dropped 1.9.3 support, in no particular order:

| gem | ruby |
| --- | --- |
| devise | >= 2.1.0 |
| rubocop | >= 2.0.0 |
| rails | >= 2.2.2 |
| capistrano | > 2.0 |
