### PR TITLE
Don't load version_association and version files for AR

### DIFF
--- a/lib/paper_trail/frameworks/active_record/models/paper_trail/version.rb
+++ b/lib/paper_trail/frameworks/active_record/models/paper_trail/version.rb
@@ -1,5 +1,3 @@
-require "paper_trail/version_concern"
-
 module PaperTrail
   # This is the default ActiveRecord model provided by PaperTrail. Most simple
   # applications will only use this and its partner, `VersionAssociation`, but

--- a/lib/paper_trail/frameworks/active_record/models/paper_trail/version_association.rb
+++ b/lib/paper_trail/frameworks/active_record/models/paper_trail/version_association.rb
@@ -1,5 +1,3 @@
-require "paper_trail/version_association_concern"
-
 module PaperTrail
   # This is the default ActiveRecord model provided by PaperTrail. Most simple
   # applications will only use this and its partner, `Version`, but it is


### PR DESCRIPTION
We don't need to load the `version_association` and `version` files for the `ActiveRecord` framework because both these files are already loaded in the main file (`paper_trial.rb`) at the moment.

I need this fix because it leads to the following exception:

```ruby
Cannot define multiple 'included' blocks for a Concern (ActiveSupport::Concern::MultipleIncludedBlocks)
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/concern.rb:126:in `included'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/paper_trail-5.2.2/lib/paper_trail/version_association_concern.rb:9:in `<module:VersionAssociationConcern>'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/paper_trail-5.2.2/lib/paper_trail/version_association_concern.rb:6:in `<module:PaperTrail>'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/paper_trail-5.2.2/lib/paper_trail/version_association_concern.rb:3:in `<top (required)>'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bootscale-0.5.2/lib/bootscale/core_ext.rb:4:in `require'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bootscale-0.5.2/lib/bootscale/core_ext.rb:4:in `require'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `block in require'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/paper_trail-5.2.2/lib/paper_trail/frameworks/active_record/models/paper_trail/version_association.rb:1:in `<top (required)>'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bootscale-0.5.2/lib/bootscale/core_ext.rb:4:in `require'
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bootscale-0.5.2/lib/bootscale/core_ext.rb:4:in `require'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `block in require'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:274:in `require'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:360:in `require_or_load'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:317:in `depend_on'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:233:in `require_dependency'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/engine.rb:472:in `block (2 levels) in eager_load!'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/engine.rb:471:in `each'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/engine.rb:471:in `block in eager_load!'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/engine.rb:469:in `each'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/engine.rb:469:in `eager_load!'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/engine.rb:346:in `eager_load!'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/application/finisher.rb:56:in `each'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/application/finisher.rb:56:in `block in <module:Finisher>'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/initializable.rb:30:in `instance_exec'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/initializable.rb:30:in `run'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-4.2.7.1/lib/rails/initializable.rb:55:in `block in run_initializers'
```

It happens in conjunction with the `bootscale` gem.