### PR TITLE
BUGFIX: Log version validation errors with ID from record

### DIFF
--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -421,7 +421,8 @@ module PaperTrail
 
     def log_version_errors(version, action)
       version.logger.warn(
-        "Unable to create version for #{action} of #{@record.class.name}##{id}: " +
+        "Unable to create version for #{action} of #{@record.class.name}#" +
+          "#{@record.id}: " +
           version.errors.full_messages.join(", ")
       )
     end


### PR DESCRIPTION
I came across a case where the logging of errors in PaperTrail is causing an exception (and hiding the underlying issue). I have a [convoluted example](https://gist.github.com/owenr/b0a3bf7cbe90b96d031e403bbee49a21) in the usual bug report format and a fix attached. No tests provided since I am unsure how to reproduce this without doing something complex or unusual.