### PR TITLE
Don't use `reset_callbacks` in tests

### DIFF
--- a/test/dummy/app/models/fluxor.rb
+++ b/test/dummy/app/models/fluxor.rb
@@ -1,7 +1,3 @@
 class Fluxor < ActiveRecord::Base
   belongs_to :widget
-
-  # In test/unit/model_test.rb and test/unit/serializer_test.rb, this is
-  # changed on the fly, which is quite confusing.
-  has_paper_trail
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -98,3 +98,28 @@ def params_wrapper(args)
     args
   end
 end
+
+module CleanupCallbacks
+  def cleanup_callbacks(target, type)
+    original_callbacks = nil
+
+    setup do
+      if ActiveRecord::VERSION::MAJOR > 3
+        original_callbacks = target.send(:get_callbacks, type).deep_dup
+      else
+        # While this defeats the purpose of targeted callback
+        # cleanup, callbacks were incredibly difficult to modify
+        # prior to Rails 4, and Rails internal callbacks were only
+        # used for autosaving associations in Rails 3. Our tests
+        # don't care whether a Fluxor's widget is autosaved.
+        target.reset_callbacks(type)
+      end
+    end
+
+    teardown do
+      if original_callbacks
+        target.send(:set_callbacks, type, original_callbacks)
+      end
+    end
+  end
+end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 require "time_travel_helper"
 
 class HasPaperTrailModelTest < ActiveSupport::TestCase
+  extend CleanupCallbacks
+
   context "A record with defined 'only' and 'ignore' attributes" do
     setup { @article = Article.create }
 
@@ -1284,6 +1286,11 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
 
   context "The `on` option" do
     context "on create" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
         Fluxor.instance_eval <<-END
           has_paper_trail :on => [:create]
@@ -1292,16 +1299,20 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         @fluxor.update_attributes name: "blah"
         @fluxor.destroy
       end
+
       should "only have a version for the create event" do
         assert_equal 1, @fluxor.versions.length
         assert_equal "create", @fluxor.versions.last.event
       end
     end
+
     context "on update" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
-        Fluxor.reset_callbacks :create
-        Fluxor.reset_callbacks :update
-        Fluxor.reset_callbacks :destroy
         Fluxor.instance_eval <<-END
           has_paper_trail :on => [:update]
         END
@@ -1309,16 +1320,20 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         @fluxor.update_attributes name: "blah"
         @fluxor.destroy
       end
+
       should "only have a version for the update event" do
         assert_equal 1, @fluxor.versions.length
         assert_equal "update", @fluxor.versions.last.event
       end
     end
+
     context "on destroy" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
-        Fluxor.reset_callbacks :create
-        Fluxor.reset_callbacks :update
-        Fluxor.reset_callbacks :destroy
         Fluxor.instance_eval <<-END
           has_paper_trail :on => [:destroy]
         END
@@ -1326,16 +1341,20 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         @fluxor.update_attributes name: "blah"
         @fluxor.destroy
       end
+
       should "only have a version for the destroy event" do
         assert_equal 1, @fluxor.versions.length
         assert_equal "destroy", @fluxor.versions.last.event
       end
     end
+
     context "on []" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
-        Fluxor.reset_callbacks :create
-        Fluxor.reset_callbacks :update
-        Fluxor.reset_callbacks :destroy
         Fluxor.instance_eval <<-END
           has_paper_trail :on => []
         END
@@ -1356,11 +1375,14 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         assert_equal 1, @fluxor.versions.length
       end
     end
+
     context "allows a symbol to be passed" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
-        Fluxor.reset_callbacks :create
-        Fluxor.reset_callbacks :update
-        Fluxor.reset_callbacks :destroy
         Fluxor.instance_eval <<-END
           has_paper_trail :on => :create
         END
@@ -1368,6 +1390,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         @fluxor.update_attributes name: "blah"
         @fluxor.destroy
       end
+
       should "only have a version for hte create event" do
         assert_equal 1, @fluxor.versions.length
         assert_equal "create", @fluxor.versions.last.event
@@ -1413,10 +1436,12 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
 
   context "custom events" do
     context "on create" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
-        Fluxor.reset_callbacks :create
-        Fluxor.reset_callbacks :update
-        Fluxor.reset_callbacks :destroy
         Fluxor.instance_eval <<-END
           has_paper_trail :on => [:create]
         END
@@ -1424,16 +1449,20 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         @fluxor.update_attributes name: "blah"
         @fluxor.destroy
       end
+
       should "only have a version for the created event" do
         assert_equal 1, @fluxor.versions.length
         assert_equal "created", @fluxor.versions.last.event
       end
     end
+
     context "on update" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
-        Fluxor.reset_callbacks :create
-        Fluxor.reset_callbacks :update
-        Fluxor.reset_callbacks :destroy
         Fluxor.instance_eval <<-END
           has_paper_trail :on => [:update]
         END
@@ -1441,16 +1470,20 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         @fluxor.update_attributes name: "blah"
         @fluxor.destroy
       end
+
       should "only have a version for the name_updated event" do
         assert_equal 1, @fluxor.versions.length
         assert_equal "name_updated", @fluxor.versions.last.event
       end
     end
+
     context "on destroy" do
+      cleanup_callbacks(Fluxor, :create)
+      cleanup_callbacks(Fluxor, :update)
+      cleanup_callbacks(Fluxor, :destroy)
+      cleanup_callbacks(Fluxor, :save)
+
       setup do
-        Fluxor.reset_callbacks :create
-        Fluxor.reset_callbacks :update
-        Fluxor.reset_callbacks :destroy
         Fluxor.instance_eval <<-END
           has_paper_trail :on => [:destroy]
         END
@@ -1458,6 +1491,7 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
         @fluxor.update_attributes name: "blah"
         @fluxor.destroy
       end
+
       should "only have a version for the destroy event" do
         assert_equal 1, @fluxor.versions.length
         assert_equal "destroyed", @fluxor.versions.last.event

--- a/test/unit/serializer_test.rb
+++ b/test/unit/serializer_test.rb
@@ -2,11 +2,14 @@ require "test_helper"
 require "custom_json_serializer"
 
 class SerializerTest < ActiveSupport::TestCase
+  extend CleanupCallbacks
+
+  cleanup_callbacks(Fluxor, :create)
+  cleanup_callbacks(Fluxor, :update)
+  cleanup_callbacks(Fluxor, :destroy)
+  cleanup_callbacks(Fluxor, :save)
+
   setup do
-    # Clean up after test/unit/model_test.rb
-    Fluxor.reset_callbacks :create
-    Fluxor.reset_callbacks :update
-    Fluxor.reset_callbacks :destroy
     Fluxor.instance_eval "has_paper_trail"
   end
 


### PR DESCRIPTION
The test suite attempts to modify a model, and then call
`reset_callbacks` to clean up after itself. However, `reset_callbacks`
removes *all* callbacks from a class, including those that Active Record
defines internally. Calling `reset_callbacks` on a class like this
basically blows away a lot of our internals.

What specifically Active Record uses callbacks for is not public API
that can be depended on, but a guarantee that it does make is that user
defined callbacks will occur after Active Record defined ones (with some
caveats like associations which are just in definition order).

Callbacks in Rails 3 were... interesting. I could not for the life of me
get it to properly clean up, and the code required to do it well would
be horrendous, so I've just left that version alone.

On that same note, since it looks like the next version is planned to be 6.0.0, how would you feel about dropping support for Rails 3 in that version? It has reached end of life, meaning it no longer receives security patches. We don't recommend that gem authors continue to support it. Users stuck on 3.2 for whatever reason can continue to use versions of `paper_trail` that are already released.

This would simplify this patch, as well as the 5.1 compatibility code.