### PR TITLE
Add support for Rails 5.1

### DIFF
--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -23,13 +23,13 @@ module PaperTrail
     end
 
     def attributes_before_change
-      @record.attributes.map do |k, v|
+      Hash[@record.attributes.map do |k, v|
         if @record.class.column_names.include?(k)
           [k, attribute_in_previous_version(k)]
         else
           [k, v]
         end
-      end.to_h
+      end]
     end
 
     def changed_and_not_ignored

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -264,7 +264,7 @@ module PaperTrail
             if options[:mark_for_destruction]
               model.send(assoc.name).mark_for_destruction if model.send(assoc.name, true)
             else
-              model.paper_trail.appear_as_new_record do
+              model.paper_trail.appear_as_unpersisted do
                 model.send "#{assoc.name}=", nil
               end
             end
@@ -277,7 +277,7 @@ module PaperTrail
                 has_and_belongs_to_many: false
               )
             )
-            model.paper_trail.appear_as_new_record do
+            model.paper_trail.appear_as_unpersisted do
               without_persisting(child) do
                 model.send "#{assoc.name}=", child
               end

--- a/test/dummy/app/models/song.rb
+++ b/test/dummy/app/models/song.rb
@@ -12,7 +12,7 @@ class Song < ActiveRecord::Base
   end
 
   if ActiveRecord::VERSION::MAJOR >= 5
-    attribute :name
+    attribute :name, :string
   else
     attr_accessor :name
 

--- a/test/dummy/app/models/song.rb
+++ b/test/dummy/app/models/song.rb
@@ -1,7 +1,6 @@
 # Example from 'Overwriting default accessors' in ActiveRecord::Base.
 class Song < ActiveRecord::Base
   has_paper_trail
-  attr_accessor :name
 
   # Uses an integer of seconds to hold the length of the song
   def length=(minutes)
@@ -12,30 +11,36 @@ class Song < ActiveRecord::Base
     read_attribute(:length) / 60
   end
 
-  # override attributes hashes like some libraries do
-  def attributes_with_name
-    if name
-      attributes_without_name.merge(name: name)
-    else
-      attributes_without_name
+  if ActiveRecord::VERSION::MAJOR >= 5
+    attribute :name
+  else
+    attr_accessor :name
+
+    # override attributes hashes like some libraries do
+    def attributes_with_name
+      if name
+        attributes_without_name.merge(name: name)
+      else
+        attributes_without_name
+      end
     end
-  end
 
-  # `alias_method_chain` is deprecated in rails 5, but we cannot use the
-  # suggested replacement, `Module#prepend`, because we still support ruby 1.9.
-  alias attributes_without_name attributes
-  alias attributes attributes_with_name
+    # `alias_method_chain` is deprecated in rails 5, but we cannot use the
+    # suggested replacement, `Module#prepend`, because we still support ruby 1.9.
+    alias attributes_without_name attributes
+    alias attributes attributes_with_name
 
-  def changed_attributes_with_name
-    if name
-      changed_attributes_without_name.merge(name: name)
-    else
-      changed_attributes_without_name
+    def changed_attributes_with_name
+      if name
+        changed_attributes_without_name.merge(name: name)
+      else
+        changed_attributes_without_name
+      end
     end
-  end
 
-  # `alias_method_chain` is deprecated in rails 5, but we cannot use the
-  # suggested replacement, `Module#prepend`, because we still support ruby 1.9.
-  alias changed_attributes_without_name changed_attributes
-  alias changed_attributes changed_attributes_with_name
+    # `alias_method_chain` is deprecated in rails 5, but we cannot use the
+    # suggested replacement, `Module#prepend`, because we still support ruby 1.9.
+    alias changed_attributes_without_name changed_attributes
+    alias changed_attributes changed_attributes_with_name
+  end
 end


### PR DESCRIPTION
This updates the code to work with Rails 5.1.0.alpha, as of commit
https://github.com/rails/rails/commit/1bdc395d956f789b6612796ac6f130cde90d3066.

The biggest change was to call the new methods provided by
`ActiveRecord::Dirty` when needed. In the next version of Rails after
5.1, dirty will be "cleared" before after_save callbacks are run. This
means that code in an after_save callback will behave the same as if it
was run after calling `.save`.

Since the concept of "changed" is fairly nebulous, two new method sets
were introduced with names that specify whether they're operating on
changes from what we think is in the database to what's in memory, or
the changes that were just persisted. Paper trail will now use the
latter set of methods if available and called from an after_ callback.

There were a few other unrelated changes required to get this working on
master. The first was the change from `appear_as_new_record` to
`appear_as_unpersisted`. This was due to a single test that broke as a
result of
https://github.com/rails/rails/commit/c546a2b045600b6d700140adf2a4df666d6e08ce
where reifying a version with a nil has_one association was persisting the
change to the foreign key. I am actually unsure how that commit caused
the problem (or more specifically, I'm unsure how it was passing
before). However, as best as I can tell, the purpose of
`appear_as_new_record` was to attempt to prevent the callbacks in
`AutosaveAssociation` (which is the module responsible for persisting
foreign key changes earlier than most people want most of the time
because backwards compatibility or the maintainer hates himself or
something) from running. By also stubbing out `persisted?` we can
actually prevent those. A more stable option might be to use `suppress`
instead, similar to the other branch in `reify_has_one`.

The remaining breakage was due to the `Song` model relying on internals
that have changed from underneath it. From Rails 5 onwards there is a
public API available to do what it wants, so we can just use that
instead.

This commit is not expected to pass on Rails 3, as #898 makes it sound
like support might be dropped. If this needs to be ammended to support
Rails 3, I will do so, but I will also grumble very loudly about it.