### PR TITLE
only warn logger if present

### DIFF
--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -505,7 +505,7 @@ module PaperTrail
       version.logger.warn(
         "Unable to create version for #{action} of #{@record.class.name}" +
           "##{@record.id}: " + version.errors.full_messages.join(", ")
-      )
+      ) if version.logger
     end
 
     # Returns true if the given HABTM association should be saved.

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -179,7 +179,7 @@ module PaperTrail
             model[k.to_sym] = v
           elsif model.respond_to?("#{k}=")
             model.send("#{k}=", v)
-          else
+          elsif version.logger
             version.logger.warn(
               "Attribute #{k} does not exist on #{version.item_type} (Version id: #{version.id})."
             )


### PR DESCRIPTION
Currently it is possible to run into this error message: `private method 'warn' called for nil:NilClass`, which will crash apps that do not have `ActiveRecord::Base.logger` set.  

It's a little confusing to draw a straight line from the original source of the error (`"Attribute #{k} does not exist on #{version.item_type} (Version id: #{version.id})."`) to the error message currently displayed in the console.

I would think it would be preferable to only call `warn` on a logger if one is present, eliminating possible sources of 500 errors and allowing developers to use `paper_trail` without explicitly setting a logger class for `PaperTrail::Version` or `ActiveRecord::Base`