### PR TITLE
Add support for per-model version_limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,8 +510,14 @@ does not apply to `create` events.
 ```ruby
 # Limit: 4 versions per record (3 most recent, plus a `create` event)
 PaperTrail.config.version_limit = 3
+
 # Remove the limit
 PaperTrail.config.version_limit = nil
+
+# Set a per-model version limit
+class Widget < ActiveRecord::Base
+  has_paper_trail :version_limit => 10
+end
 ```
 
 ## 3. Working With Versions

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -310,12 +310,17 @@ module PaperTrail
     # option, and if so enforces it.
     # @api private
     def enforce_version_limit!
-      limit = PaperTrail.config.version_limit
+      limit = paper_trail_options[:version_limit] || PaperTrail.config.version_limit
       return unless limit.is_a? Numeric
       previous_versions = sibling_versions.not_creates
       return unless previous_versions.size > limit
       excess_versions = previous_versions - previous_versions.last(limit)
       excess_versions.map(&:destroy)
+    end
+
+    # @api private
+    def paper_trail_options
+      item ? item.paper_trail_options : {}
     end
   end
 end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1496,4 +1496,19 @@ class HasPaperTrailModelTest < ActiveSupport::TestCase
       assert_equal 3, @widget.versions.size
     end
   end
+
+  context "per-model version_limit" do
+    setup do
+      Fluxor.instance_eval <<-END
+        has_paper_trail :version_limit => 3
+      END
+      @fluxor = Fluxor.create! name: "Foo"
+      6.times { @fluxor.update_attribute(:name, FFaker::Lorem.word) }
+    end
+
+    should "limit the number of versions to 4 (3 plus the created at event)" do
+      assert_equal "create", @fluxor.versions.first.event
+      assert_equal 4, @fluxor.versions.size
+    end
+  end
 end


### PR DESCRIPTION
This is the same feature as suggested in https://github.com/airblade/paper_trail/pull/781, but implemented as a `has_paper_trail` option:

```ruby
class Widget < ActiveRecord::Base
  has_paper_trail :version_limit => 10
end
```

One thing I was not 100% sure about when implementing the change is whether it's safe to call `item` in the `after_create` callback. I'm not really familiar with the codebase so it's hard to tell if there is a scenario where the `item` is not loaded and this will result in an extra DB query.. please advise :)

*If that does create an issue the code could be changed to something like* `item_type.constantize.paper_trail_options[:version_limit]`
