### PR TITLE
Explain the scope of `without_versioning`

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ Or a block:
 end
 ```
 
-_Note_: `without_versioning` disables PaperTrail for the model
+PaperTrail is disabled for the whole model
 (e.g. `Widget`), not just for the instance (e.g. `@widget`).
 
 ### 2.e. Limiting the Number of Versions Created

--- a/README.md
+++ b/README.md
@@ -498,6 +498,9 @@ Or a block:
 end
 ```
 
+_Note_: `without_versioning` disables PaperTrail for the model
+(e.g. `Widget`), not just for the instance (e.g. `@widget`).
+
 ### 2.e. Limiting the Number of Versions Created
 
 Configure `version_limit` to cap the number of versions saved per record. This


### PR DESCRIPTION
Per a conversation with @batter in issue #916, adds a note to the README that explains the scope of #without_versioning.
