### PR TITLE
Changelog: Enum-related breaking change in v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,10 @@ name conflict with your methods.
 
 ## 4.1.0 (2016-01-30)
 
+### Known Issues
+
+- Version changesets now store ENUM values incorrectly (as nulls). Previously the values were stored as strings. This only affects Rails 4, not Rails 5. See [#926](https://github.com/airblade/paper_trail/pull/926)
+
 ### Breaking Changes
 
 - None


### PR DESCRIPTION
A breaking change from `v4.0.2` to `v4.1.0` is not documented in the [changelog](https://github.com/airblade/paper_trail/blob/master/CHANGELOG.md#410-2016-01-30).

Arguably this is the introduction of a bug, rather than a deliberate change, so perhaps it is not worth adding to the changelog.

The behaviour change is around retrieval of `enum` values from a version's changeset. After the update, the display behaviour seems to have changed from string-based to integer-based.

To reproduce this, I used the following code:

```ruby
# my_model.rb
class MyModel < ActiveRecord::Base
  enum my_enum: { foo: 4, bar: 5 }
  has_paper_trail
end

# Create the version
sample = MyModel.create(my_enum: :foo)
sample.update!(my_enum: :bar)

# displaying human-readable changeset
changeset = MyModel.last.versions.last.changeset
from = changeset['my_enum'][0]
to = changeset['my_enum'][1]
puts "Enum value changed from '#{from}' to '#{to}'."
```

Output under `paper_trail` from `4.0.2`:
> Enum value changed from 'foo' to 'bar'.

Output under `paper_trail` from `4.1.0`.
> Enum value changed from '0' to '0'.

I've not checked the behaviour of the latest `paper_trail` version; this proposal is simply to fix the changelog (even though it is for quite an outdated version).