### PR TITLE
use send() for #attribute_was (private in Rails 4.0)

### DIFF
--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -474,7 +474,7 @@ module PaperTrail
       if @in_after_callback && RAILS_GTE_5_1
         @record.attribute_before_last_save(attr_name.to_s)
       else
-        @record.attribute_was(attr_name.to_s)
+        @record.send(:attribute_was, attr_name.to_s)
       end
     end
 


### PR DESCRIPTION
`private method 'attribute_was' called for ...` is what you currently get trying to use paper_trail (6.0.2) with Rails 4.0(.13). See similar problem in https://github.com/lwe/simple_enum/issues/70.