### PR TITLE
Add rubocop extensions: rubocop-rspec and rubocop-thread_safety

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-rspec
+  - rubocop-thread_safety
+
 inherit_from: .rubocop_todo.yml
 
 # Please:
@@ -105,3 +109,7 @@ Style/StringLiterals:
 # because it makes the code harder to edit, and makes lines unnecessarily long.
 Style/SpaceAroundOperators:
   AllowForAlignment: false
+
+ThreadSafety/NewThread:
+  Exclude:
+    - 'test/functional/thread_safety_test.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 # Remove these configuration records
 # one by one as the offenses are removed from the code base.
 
@@ -11,4 +13,22 @@ Metrics/PerceivedComplexity:
   Max: 9 # Goal: 7
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/ExampleWording:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/NotToNot:
+  Enabled: false
+
+RSpec/FilePath:
   Enabled: false

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -42,6 +42,8 @@ has been destroyed.
   s.add_development_dependency "database_cleaner", "~> 1.2"
   s.add_development_dependency "pry-nav", "~> 0.2.4"
   s.add_development_dependency "rubocop", "~> 0.41.1"
+  s.add_development_dependency "rubocop-rspec", "~> 1.5.1"
+  s.add_development_dependency "rubocop-thread_safety", "~> 0.3.1"
   s.add_development_dependency "timecop", "~> 0.8.0"
   s.add_development_dependency "sqlite3", "~> 1.2"
   s.add_development_dependency "pg", "~> 0.19.0"

--- a/spec/modules/version_number_spec.rb
+++ b/spec/modules/version_number_spec.rb
@@ -34,10 +34,3 @@ describe PaperTrail::VERSION do
     end
   end
 end
-
-describe PaperTrail do
-  describe "#version" do
-    it { is_expected.to respond_to(:version) }
-    it { expect(subject.version).to eq(PaperTrail::VERSION::STRING) }
-  end
-end

--- a/spec/paper_trail_spec.rb
+++ b/spec/paper_trail_spec.rb
@@ -61,6 +61,11 @@ describe PaperTrail do
     end
   end
 
+  describe :version do
+    it { PaperTrail.to respond_to(:version) }
+    it { expect(PaperTrail.version).to eq(PaperTrail::VERSION::STRING) }
+  end
+
   describe :whodunnit do
     before(:all) { PaperTrail.whodunnit = "foobar" }
 


### PR DESCRIPTION
So, apparently `PaperTrail.config` is not thread-safe:

```
    def config
      @config ||= PaperTrail::Config.instance
      yield @config if block_given?
      @config
    end
```