### PR TITLE
Fix belongs_to reify for associations that use a different foreign_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
   matchers to work with custom version association names
 - [#929](https://github.com/airblade/paper_trail/pull/929) -
   Fix error calling private method in rails 4.0
+- [#938](https://github.com/airblade/paper_trail/pull/938) - Fix bug where
+  non-standard foreign key names broke belongs_to associations
 
 ## 6.0.2 (2016-12-13)
 

--- a/lib/paper_trail/reifiers/belongs_to.rb
+++ b/lib/paper_trail/reifiers/belongs_to.rb
@@ -6,7 +6,7 @@ module PaperTrail
       class << self
         # @api private
         def reify(assoc, model, options, transaction_id)
-          id = model.send(assoc.association_foreign_key)
+          id = model.send(assoc.foreign_key)
           version = load_version(assoc, id, transaction_id, options[:version_at])
           record = load_record(assoc, id, options, version)
           model.send("#{assoc.name}=".to_sym, record)

--- a/test/dummy/app/models/person.rb
+++ b/test/dummy/app/models/person.rb
@@ -1,6 +1,7 @@
 class Person < ActiveRecord::Base
   has_many :authorships, foreign_key: :author_id, dependent: :destroy
   has_many :books, through: :authorships
+  belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id
   has_paper_trail
 
   # Convert strings to TimeZone objects when assigned

--- a/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/test/dummy/db/migrate/20110208155312_set_up_test_tables.rb
@@ -166,6 +166,7 @@ class SetUpTestTables < ActiveRecord::Migration
     create_table :people, force: true do |t|
       t.string :name
       t.string :time_zone
+      t.integer :mentor_id
     end
 
     create_table :editorships, force: true do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -174,8 +174,9 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   end
 
   create_table "people", force: :cascade do |t|
-    t.string "name"
-    t.string "time_zone"
+    t.string  "name"
+    t.string  "time_zone"
+    t.integer "mentor_id"
   end
 
   create_table "post_versions", force: :cascade do |t|


### PR DESCRIPTION
Paper trail currently fails to reify belongs to associations that use a non-standard foreign key. You can see this by spinning up an example rails app:
```
rails g model Person name:string
rails g model Dog name:string owner_id:integer

# app/models/person.rb
class Person < ApplicationRecord
  has_paper_trail
end

# app/models/dog.rb
class Dog < ApplicationRecord
  has_paper_trail
  belongs_to :person, foreign_key: :owner_id
end
```
and then creating a few models and attempting to do `dog.versions.last.reify(belongs_to: true)`. You get:
```
irb(main):002:0> dog.versions.last.reify(belongs_to: true)
  PaperTrail::Version Load (0.2ms)  SELECT  "versions".* FROM "versions" WHERE "versions"."item_id" = ? AND "versions"."item_type" = ? ORDER BY "versions"."created_at" DESC, "versions"."id" DESC LIMIT ?  [["item_id", 1], ["item_type", "Dog"], ["LIMIT", 1]]
  Dog Load (0.1ms)  SELECT  "dogs".* FROM "dogs" WHERE "dogs"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
NoMethodError: undefined method `person_id' for #<Dog:0x005642ccdf5290>
```

`PaperTrail::Reifiers::BelongsTo`, I believe, is checking the wrong association method to get its foreign key. It can just check `assoc.foreign_key` instead of `assoc.association_foreign_key` which I believe is designed for `has_many` situations. Happy to provide any other information or do any extra work it takes to get this merged in. Also, I'm not sure if you guys do backports, but my work is currently using paper trail 5, so it would be great to get it merged in there as well if possible!