### PR TITLE
When enforcing version_limit, order the version records by created_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
   Fix error calling private method in rails 4.0
 - [#938](https://github.com/airblade/paper_trail/pull/938) - Fix bug where
   non-standard foreign key names broke belongs_to associations
+- [#940](https://github.com/airblade/paper_trail/pull/940) - When destroying
+  versions to stay under version_limit, don't rely on the database to
+  implicitly return the versions in the right order
 
 ## 6.0.2 (2016-12-13)
 

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -240,7 +240,9 @@ module PaperTrail
 
     def sibling_versions(reload = false)
       if reload || @sibling_versions.nil?
-        @sibling_versions = self.class.with_item_keys(item_type, item_id)
+        @sibling_versions = self.class.
+          with_item_keys(item_type, item_id).
+          order(self.class.timestamp_sort_order('asc'))
       end
       @sibling_versions
     end

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -240,9 +240,7 @@ module PaperTrail
 
     def sibling_versions(reload = false)
       if reload || @sibling_versions.nil?
-        @sibling_versions = self.class.
-          with_item_keys(item_type, item_id).
-          order(self.class.timestamp_sort_order('asc'))
+        @sibling_versions = self.class.with_item_keys(item_type, item_id)
       end
       @sibling_versions
     end
@@ -314,7 +312,8 @@ module PaperTrail
     def enforce_version_limit!
       limit = PaperTrail.config.version_limit
       return unless limit.is_a? Numeric
-      previous_versions = sibling_versions.not_creates
+      previous_versions = sibling_versions.not_creates.
+        order(self.class.timestamp_sort_order("asc"))
       return unless previous_versions.size > limit
       excess_versions = previous_versions - previous_versions.last(limit)
       excess_versions.map(&:destroy)

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+module PaperTrail
+  RSpec.describe Cleaner, versioning: true do
+    before do
+      @last_limit = PaperTrail.config.version_limit
+    end
+    after do
+      PaperTrail.config.version_limit = @last_limit
+    end
+
+    it 'cleans up old versions' do
+      PaperTrail.config.version_limit = 10
+      widget = Widget.create
+
+      100.times do |i|
+        widget.update_attributes(name: "Name #{i}")
+        expect(Widget.find(widget.id).versions.count).to be <= 11
+        # 11 versions = 10 updates + 1 create.
+      end
+    end
+  end
+end

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -19,5 +19,79 @@ module PaperTrail
         # 11 versions = 10 updates + 1 create.
       end
     end
+
+    it "cleans them up in the right order, even if the database query returns them in a different order" do
+      epoch = DateTime.new(2017, 1, 1)
+
+      # Turn off the version_limit, and make a bunch of versions.
+      PaperTrail.config.version_limit = nil
+
+      widget = Timecop.freeze(epoch) do
+        Widget.create(name: 'Starting Name')
+      end
+
+      Timecop.freeze(epoch + 1.hours) { widget.update_attributes(name: 'Name 1') }
+      Timecop.freeze(epoch + 2.hours) { widget.update_attributes(name: 'Name 2') }
+      Timecop.freeze(epoch + 3.hours) { widget.update_attributes(name: 'Name 3') }
+      Timecop.freeze(epoch + 4.hours) { widget.update_attributes(name: 'Name 4') }
+      Timecop.freeze(epoch + 5.hours) { widget.update_attributes(name: 'Name 5') }
+
+      # Here comes the crazy part.
+      #
+      # We want the database to return PaperTrail::Versions out of order. So
+      # we'll delete what's there, shuffle them, and re-create them, but with
+      # the same data, including the created_at timestamps. This will simulate
+      # what happens when the database optimizes a query, and returns the
+      # records in a different order than they were inserted in.
+      # Load the records:
+      versions = PaperTrail::Version.where(item: widget).not_creates.to_a
+
+      # Delete the records, but don't let the in-memory objects know.
+      PaperTrail::Version.where(id: versions.map(&:id)).delete_all
+
+      # Are the versions deleted?
+      expect(Widget.find(widget.id).versions.count).to eq(1)
+      # Yes: only the create is left.
+
+      # Shuffle them, and re-create them.
+      versions.shuffle.each do |version|
+        Timecop.freeze(version.created_at) do
+          PaperTrail::Version.create!(
+            event: version.event,
+            item_type: version.item_type,
+            item_id: version.item_id,
+            object: version.object,
+          )
+        end
+      end
+      expect(Widget.find(widget.id).versions.count).to eq(6)
+
+      # Sorting by ID should match insertion order. We can be confident that
+      # the records are out of order, if sorting by ID doesn't match sorting by
+      # created_at.
+      ids_and_dates = PaperTrail::Version.
+        where(item: widget, event: 'update').
+        pluck(:id, :created_at)
+      expect(ids_and_dates.sort_by(&:first)).to_not eq(
+        ids_and_dates.sort_by(&:last)
+      )
+
+      # Now, we've recreated the scenario where we can accidentally clean up
+      # the wrong versions. Re-enable the version_limit, and make one more
+      # wafer-thin update, to trigger the clean-up:
+      PaperTrail.config.version_limit = 3
+      Timecop.freeze(epoch + 6.hours) do
+        widget.update_attributes(name: 'Mr. Creosote')
+      end
+
+      # Verify that we have fewer versions:
+      expect(widget.reload.versions.count).to eq(4)
+
+      # Exclude the create, because the create will return nil for `#reify`.
+      last_names = widget.versions.not_creates.map(&:reify).map(&:name)
+      expect(last_names).to eq(['Name 3', 'Name 4', 'Name 5'])
+      # No matter what order the version records are returned it, we should
+      # always keep the most-recent changes.
+    end
   end
 end

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -23,73 +23,35 @@ module PaperTrail
     it "cleans them up in the right order, even if the database query returns them in a different order" do
       epoch = DateTime.new(2017, 1, 1)
 
-      # Turn off the version_limit, and make a bunch of versions.
-      PaperTrail.config.version_limit = nil
+      widget = Timecop.freeze(epoch) { Widget.create }
 
-      widget = Timecop.freeze(epoch) do
-        Widget.create(name: 'Starting Name')
-      end
-
-      Timecop.freeze(epoch + 1.hours) { widget.update_attributes(name: 'Name 1') }
-      Timecop.freeze(epoch + 2.hours) { widget.update_attributes(name: 'Name 2') }
-      Timecop.freeze(epoch + 3.hours) { widget.update_attributes(name: 'Name 3') }
-      Timecop.freeze(epoch + 4.hours) { widget.update_attributes(name: 'Name 4') }
-      Timecop.freeze(epoch + 5.hours) { widget.update_attributes(name: 'Name 5') }
-
-      # Here comes the crazy part.
-      #
-      # We want the database to return PaperTrail::Versions out of order. So
-      # we'll delete what's there, shuffle them, and re-create them, but with
-      # the same data, including the created_at timestamps. This will simulate
-      # what happens when the database optimizes a query, and returns the
-      # records in a different order than they were inserted in.
-      # Load the records:
-      versions = PaperTrail::Version.where(item: widget).not_creates.to_a
-
-      # Delete the records, but don't let the in-memory objects know.
-      PaperTrail::Version.where(id: versions.map(&:id)).delete_all
-
-      # Are the versions deleted?
-      expect(Widget.find(widget.id).versions.count).to eq(1)
-      # Yes: only the create is left.
-
-      # Shuffle them, and re-create them.
-      versions.shuffle.each do |version|
-        Timecop.freeze(version.created_at) do
+      # Sometimes a database will returns records in a different order than
+      # they were inserted. That's hard to get the database to do, so we'll
+      # just create them out-of-order:
+      (1..5).to_a.shuffle.each do |n|
+        Timecop.freeze(epoch + n.hours) do
           PaperTrail::Version.create!(
-            event: version.event,
-            item_type: version.item_type,
-            item_id: version.item_id,
-            object: version.object,
+            item: widget,
+            event: "update",
+            #object: { "id" => widget.id, "name" => "Name #{n}" }.to_yaml
+            object: { "id" => widget.id, "name" => "Name #{n}" }.to_yaml
           )
         end
       end
-      expect(Widget.find(widget.id).versions.count).to eq(6)
-
-      # Sorting by ID should match insertion order. We can be confident that
-      # the records are out of order, if sorting by ID doesn't match sorting by
-      # created_at.
-      ids_and_dates = PaperTrail::Version.
-        where(item: widget, event: 'update').
-        pluck(:id, :created_at)
-      expect(ids_and_dates.sort_by(&:first)).to_not eq(
-        ids_and_dates.sort_by(&:last)
-      )
+      expect(Widget.find(widget.id).versions.count).to eq(6) # 1 create + 5 updates
 
       # Now, we've recreated the scenario where we can accidentally clean up
-      # the wrong versions. Re-enable the version_limit, and make one more
-      # wafer-thin update, to trigger the clean-up:
+      # the wrong versions. Re-enable the version_limit, and trigger the
+      # clean-up:
       PaperTrail.config.version_limit = 3
-      Timecop.freeze(epoch + 6.hours) do
-        widget.update_attributes(name: 'Mr. Creosote')
-      end
+      widget.versions.last.send(:enforce_version_limit!)
 
       # Verify that we have fewer versions:
-      expect(widget.reload.versions.count).to eq(4)
+      expect(widget.reload.versions.count).to eq(4) # 1 create + 4 updates
 
       # Exclude the create, because the create will return nil for `#reify`.
       last_names = widget.versions.not_creates.map(&:reify).map(&:name)
-      expect(last_names).to eq(['Name 3', 'Name 4', 'Name 5'])
+      expect(last_names).to eq(["Name 3", "Name 4", "Name 5"])
       # No matter what order the version records are returned it, we should
       # always keep the most-recent changes.
     end

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -33,7 +33,6 @@ module PaperTrail
           PaperTrail::Version.create!(
             item: widget,
             event: "update",
-            #object: { "id" => widget.id, "name" => "Name #{n}" }.to_yaml
             object: { "id" => widget.id, "name" => "Name #{n}" }.to_yaml
           )
         end

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -20,7 +20,7 @@ module PaperTrail
       end
     end
 
-    it "cleans them up in the right order, even if the database query returns them in a different order" do
+    it "deletes oldest versions, when the database returns them in a different order" do
       epoch = DateTime.new(2017, 1, 1)
 
       widget = Timecop.freeze(epoch) { Widget.create }

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 module PaperTrail
   RSpec.describe Cleaner, versioning: true do
@@ -9,7 +9,7 @@ module PaperTrail
       PaperTrail.config.version_limit = @last_limit
     end
 
-    it 'cleans up old versions' do
+    it "cleans up old versions" do
       PaperTrail.config.version_limit = 10
       widget = Widget.create
 


### PR DESCRIPTION
The details of the issue are in #940.

I split the commits out into visible, obvious parts. If you checkout the middle commit, db4c586, you can see the failure by running `rake spec`. I'm more than happy to squash these down, if the maintainers would like.