### PR TITLE
have_a_version_with_changes or have_a_version_with

### DIFF
--- a/README.md
+++ b/README.md
@@ -1417,9 +1417,9 @@ describe '`have_a_version_with_changes` matcher' do
   end
 
   it "is possible to do assertions on version changes" do
-    expect(widget).to have_a_version_with name: 'Leonard', an_integer: 2
-    expect(widget).to have_a_version_with an_integer: 2
-    expect(widget).to have_a_version_with name: 'Bob'
+    expect(widget).to have_a_version_with_changes name: 'Leonard', an_integer: 2
+    expect(widget).to have_a_version_with_changes an_integer: 2
+    expect(widget).to have_a_version_with_changes name: 'Bob'
   end
 end
 ```

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -41,7 +41,7 @@ has been destroyed.
   s.add_development_dependency "generator_spec", "~> 0.9.3"
   s.add_development_dependency "database_cleaner", "~> 1.2"
   s.add_development_dependency "pry-nav", "~> 0.2.4"
-  s.add_development_dependency "rubocop", "~> 0.48.0"
+  s.add_development_dependency "rubocop", "0.48.0"
   s.add_development_dependency "rubocop-rspec", "~> 1.15.0"
   s.add_development_dependency "timecop", "~> 0.8.0"
   s.add_development_dependency "sqlite3", "~> 1.2"


### PR DESCRIPTION
Could it be, that it's the `have_a_version_with_changes` matcher instead of `have_a_version_with`