### PR TITLE
Lock rubocop at 0.48.0 for now

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -41,7 +41,7 @@ has been destroyed.
   s.add_development_dependency "generator_spec", "~> 0.9.3"
   s.add_development_dependency "database_cleaner", "~> 1.2"
   s.add_development_dependency "pry-nav", "~> 0.2.4"
-  s.add_development_dependency "rubocop", "~> 0.48.0"
+  s.add_development_dependency "rubocop", "0.48.0"
   s.add_development_dependency "rubocop-rspec", "~> 1.15.0"
   s.add_development_dependency "timecop", "~> 0.8.0"
   s.add_development_dependency "sqlite3", "~> 1.2"


### PR DESCRIPTION
0.48.1 has breaking changes