### PR TITLE
Fix ActiveRecord version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#956](https://github.com/airblade/paper_trail/pull/956) -
+  Fix ActiveRecord >= 5.1 version check 
 
 ## 7.0.1 (2017-04-10)
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -1,7 +1,8 @@
 module PaperTrail
   # Represents the "paper trail" for a single record.
   class RecordTrail
-    RAILS_GTE_5_1 = ::ActiveRecord::VERSION::MAJOR >= 5 && ::ActiveRecord::VERSION::MINOR >= 1
+    RAILS_GTE_5_1 = ::ActiveRecord::VERSION::MAJOR > 5 ||
+                    (::ActiveRecord::VERSION::MAJOR == 5 && ::ActiveRecord::VERSION::MINOR >= 1)
 
     def initialize(record)
       @record = record

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -1,8 +1,8 @@
 module PaperTrail
   # Represents the "paper trail" for a single record.
   class RecordTrail
-    RAILS_GTE_5_1 = ::ActiveRecord::VERSION::MAJOR > 5 ||
-                    (::ActiveRecord::VERSION::MAJOR == 5 && ::ActiveRecord::VERSION::MINOR >= 1)
+    RAILS_GTE_5_1 = ::ActiveRecord.respond_to?(:gem_version) &&
+      ::ActiveRecord.gem_version >= ::Gem::Version.new("5.1.0.beta1")
 
     def initialize(record)
       @record = record


### PR DESCRIPTION
Minor change: the `RAILS_GTE_5_1` version check in `record_trail.rb` looks wrong to me. It checks that ActiveRecord's major version is at least 5 and minor version is at least 1, but I think this check would exclude releases like 6.0 and 7.0.

I've changed the check to one that will match what I think was intended.

Thanks for your hard work on this gem; it's been working great for us so far!