### PR TITLE
Allow `whodunnit` to be a proc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,10 +15,7 @@ Please use our [bug report template][1].
 
 ## Development
 
-Install gems with `bundle exec appraisal install`, run tests with `bundle exec appraisal rake`.
-This requires ruby >= 2.0.
-(It is still possible to run the `ar-4.2` gemfile locally on ruby 1.9.3, but
-not the `ar-5.0` gemfile.)
+Install gems with `bundle exec appraisal install`.
 
 Testing is a little awkward because the test suite:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,8 @@ Please use our [bug report template][1].
 
 ## Development
 
-Install gems with `bundle exec appraisal install`. This requires ruby >= 2.0.
+Install gems with `bundle exec appraisal install`, run tests with `bundle exec appraisal rake`.
+This requires ruby >= 2.0.
 (It is still possible to run the `ar-4.2` gemfile locally on ruby 1.9.3, but
 not the `ar-5.0` gemfile.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,14 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
-- `Papertrail.whodunnit` accepts a `proc` (or other object that responds to `call`)
-
 ### Breaking Changes
 
 - None
 
 ### Added
 
-- None
+- [#976](https://github.com/airblade/paper_trail/pull/976)
+  `PaperTrail.whodunnit` accepts a `Proc`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
+- `Papertrail.whodunnit` accepts a `proc` (or other object that responds to `call`)
+
 ### Breaking Changes
 
 - None

--- a/README.md
+++ b/README.md
@@ -716,10 +716,11 @@ PaperTrail.whodunnit('Dorian Marié') do
 end
 ```
 
-`whodunnit` also accepts a proc, if you find yourself needing a dynamic value.
+`whodunnit` also accepts a `Proc`.
+
 ```ruby
 PaperTrail.whodunnit = proc do
-  caller.first{|c| c.starts_with? Rails.root.to_s}
+  caller.first{ |c| c.starts_with? Rails.root.to_s }
 end
 ```
 
@@ -1543,7 +1544,7 @@ https://github.com/airblade/paper_trail/graphs/contributors
 
 ## Contributing
 
-See our [contribution guidelines](https://github.com/airblade/paper_trail/blob/master/.github/CONTRIBUTING.md)
+See our [contribution guidelines][43]
 
 ## Inspirations
 
@@ -1593,3 +1594,4 @@ Released under the MIT licence.
 [40]: http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Polymorphic+Associations
 [41]: https://github.com/jaredbeck/paper_trail-sinatra
 [42]: https://github.com/activeadmin/activeadmin/wiki/Auditing-via-paper_trail-%28change-history%29
+[43]: https://github.com/airblade/paper_trail/blob/master/.github/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1541,6 +1541,10 @@ by Jared Beck, with contributions by over 150 people.
 
 https://github.com/airblade/paper_trail/graphs/contributors
 
+## Contributing
+
+See our [contribution guidelines](https://github.com/airblade/paper_trail/blob/master/.github/CONTRIBUTING.md)
+
 ## Inspirations
 
 * [Simply Versioned](http://github.com/github/simply_versioned)

--- a/README.md
+++ b/README.md
@@ -716,6 +716,13 @@ PaperTrail.whodunnit('Dorian Marié') do
 end
 ```
 
+`whodunnit` also accepts a proc, if you find yourself needing a dynamic value.
+```ruby
+PaperTrail.whodunnit = proc do
+  caller.first{|c| c.starts_with? Rails.root.to_s}
+end
+```
+
 If your controller has a `current_user` method, PaperTrail provides a
 `before_action` that will assign `current_user.id` to `PaperTrail.whodunnit`.
 You can add this `before_action` to your `ApplicationController`.

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -111,6 +111,8 @@ module PaperTrail
         ensure
           paper_trail_store[:whodunnit] = previous_whodunnit
         end
+      elsif paper_trail_store[:whodunnit].respond_to?(:call)
+        paper_trail_store[:whodunnit].call
       else
         paper_trail_store[:whodunnit]
       end

--- a/spec/paper_trail_spec.rb
+++ b/spec/paper_trail_spec.rb
@@ -101,6 +101,15 @@ RSpec.describe PaperTrail do
         expect(described_class.whodunnit).to be_nil
       end
     end
+
+    context "when set to a proc" do
+      it "evaluates the proc each time a version is made" do
+        call_count = 0
+        described_class.whodunnit = proc { call_count += 1 }
+        expect(described_class.whodunnit).to eq(1)
+        expect(described_class.whodunnit).to eq(2)
+      end
+    end
   end
 
   describe ".controller_info" do


### PR DESCRIPTION
Basically, I've got a circumstance where I'm trying to figure out *what* is changing one of my models (it's not Sidekiq jobs, and it's not going through the controllers...).

Right now I've got:

```
class PapertrailSidekiqMiddleware
  def call(worker_class, job, queue)
    if(worker_class.class == Sidekiq::Extensions::DelayedClass)
      PaperTrail.whodunnit = YAML.load(job["args"].first).first.to_s
    else
      PaperTrail.whodunnit = worker_class.class.to_s
    end
    yield
  end
end

Sidekiq.configure_server do |config|
  config.server_middleware do |chain|
    chain.add PapertrailSidekiqMiddleware
  end
end
```

This works, but it also only covers Sidekiq; if there's no place to stick the `whodunnit` initialization like this, there's no way to make the `whodunnit` dynamic and record the actual situation.

However, with a change like this, you could set a whodunnit during the creation of the paper trail, so you could evaluate anything you like (inspecting the callstack, the originally run Ruby command, etc etc).

PS - Honestly, I was 100% convinced I wanted this feature as part of tracking down this issue, but in this moment I'm honestly no remembering what the plan was that needed it.... :P

PPS - I totally don't expect this PR to get accepted, but I wanted to start the conversation and figured this'd be more illustrative than making an issue. LMK how I should proceed!

PPPS -  I also ran into a couple of issues when first running `rspec` on Papertrail, so there's a couple of Gemfile commits to fix that.