### PR TITLE
Fixes uninitialized constant PaperTrail::RecordTrail::ActiveRecordError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - Stop including unnecessary files in released gem. Reduces .gem file size
   from 100K to 30K.
+- [#984](https://github.com/airblade/paper_trail/pull/984) - Fix wrong
+  exception in `touch_with_version` if record object isn't persisted
 
 ## 7.1.0 (2017-07-09)
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -399,7 +399,7 @@ module PaperTrail
     # leverage an `after_update` callback anyways (likely for v4.0.0)
     def touch_with_version(name = nil)
       unless @record.persisted?
-        raise ActiveRecordError, "can not touch on a new record object"
+        raise ::ActiveRecord::ActiveRecordError, "can not touch on a new record object"
       end
       attributes = @record.send :timestamp_attributes_for_update_in_model
       attributes << name if name


### PR DESCRIPTION
Fixes #663.

I didn't found the right place for the spec so I put it in `spec/models/thing_spec.rb`:

```ruby
  describe "#touch_with_version", versioning: true do
    let(:thing) { Thing.new(name: "pencil") }

    context "when record isn't persisted" do
      it "raises an error" do
        expect {
          thing.paper_trail.touch_with_version
        }.to raise_error(ActiveRecord::ActiveRecordError, "can not touch on a new record object")
      end
    end
```

Without the fix the spec would say:
```
expected ActiveRecord::ActiveRecordError with "can not touch on a new record object",
got #<NameError: uninitialized constant PaperTrail::RecordTrail::ActiveRecordError> with backtrace:
# ./lib/paper_trail/record_trail.rb:402:in `touch_with_version'
```

It's the exception I had in the app I'm working on. The message doesn't help so I was forced to look into the code.
