### PR TITLE
Support belongs_to_required_by_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#985](https://github.com/airblade/paper_trail/pull/985) - Fix RecordInvalid error on nil item
+  association when belongs_to_required_by_default is enabled.
 
 ## 7.1.1 (2017-08-18)
 

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -12,7 +12,11 @@ module PaperTrail
     extend ::ActiveSupport::Concern
 
     included do
-      belongs_to :item, polymorphic: true
+      if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+        belongs_to :item, polymorphic: true, optional: true
+      else
+        belongs_to :item, polymorphic: true
+      end
 
       # Since the test suite has test coverage for this, we want to declare
       # the association when the test suite is running. This makes it pass when

--- a/spec/dummy_app/app/models/callback_modifier.rb
+++ b/spec/dummy_app/app/models/callback_modifier.rb
@@ -20,9 +20,14 @@ class BeforeDestroyModifier < CallbackModifier
   paper_trail.on_destroy :before
 end
 
-class AfterDestroyModifier < CallbackModifier
-  has_paper_trail on: []
-  paper_trail.on_destroy :after
+if ActiveRecord.gem_version < Gem::Version.new("5") ||
+    !ActiveRecord::Base.belongs_to_required_by_default
+
+  class AfterDestroyModifier < CallbackModifier
+    has_paper_trail on: []
+    paper_trail.on_destroy :after
+  end
+
 end
 
 class NoArgDestroyModifier < CallbackModifier

--- a/spec/dummy_app/app/models/fluxor.rb
+++ b/spec/dummy_app/app/models/fluxor.rb
@@ -1,3 +1,7 @@
 class Fluxor < ActiveRecord::Base
-  belongs_to :widget
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :widget, optional: true
+  else
+    belongs_to :widget
+  end
 end

--- a/spec/dummy_app/app/models/person.rb
+++ b/spec/dummy_app/app/models/person.rb
@@ -1,7 +1,13 @@
 class Person < ActiveRecord::Base
   has_many :authorships, foreign_key: :author_id, dependent: :destroy
   has_many :books, through: :authorships
-  belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id
+
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id, optional: true
+  else
+    belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id
+  end
+
   has_paper_trail
 
   # Convert strings to TimeZone objects when assigned

--- a/spec/dummy_app/app/models/whatchamajigger.rb
+++ b/spec/dummy_app/app/models/whatchamajigger.rb
@@ -1,4 +1,9 @@
 class Whatchamajigger < ActiveRecord::Base
   has_paper_trail
-  belongs_to :owner, polymorphic: true
+
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :owner, polymorphic: true, optional: true
+  else
+    belongs_to :owner, polymorphic: true
+  end
 end

--- a/spec/dummy_app/app/models/wotsit.rb
+++ b/spec/dummy_app/app/models/wotsit.rb
@@ -1,6 +1,11 @@
 class Wotsit < ActiveRecord::Base
   has_paper_trail
-  belongs_to :widget
+
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :widget, optional: true
+  else
+    belongs_to :widget
+  end
 
   def created_on
     created_at.to_date

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -31,7 +31,12 @@ module Dummy
       if v >= Gem::Version.new("4.2") && v < Gem::Version.new("5.0.0.beta1")
         config.active_record.raise_in_transactional_callbacks = true
       end
-      if v >= Gem::Version.new("5.0.0.beta1")
+      if v >= Gem::Version.new("5.0.0.beta1") && v < Gem::Version.new("5.1")
+        config.active_record.belongs_to_required_by_default = true
+        config.active_record.time_zone_aware_types = [:datetime]
+      end
+      if v >= Gem::Version.new("5.1")
+        config.load_defaults "5.1"
         config.active_record.time_zone_aware_types = [:datetime]
       end
     end

--- a/spec/models/callback_modifier_spec.rb
+++ b/spec/models/callback_modifier_spec.rb
@@ -15,12 +15,17 @@ RSpec.describe CallbackModifier, type: :model, versioning: true do
       end
     end
 
-    context "when :after" do
-      it "creates the version after destroy" do
-        modifier = AfterDestroyModifier.create!(some_content: FFaker::Lorem.sentence)
-        modifier.test_destroy
-        expect(modifier.versions.last.reify).to be_flagged_deleted
+    if ActiveRecord.gem_version < Gem::Version.new("5") ||
+        !ActiveRecord::Base.belongs_to_required_by_default
+
+      context "when :after" do
+        it "creates the version after destroy" do
+          modifier = AfterDestroyModifier.create!(some_content: FFaker::Lorem.sentence)
+          modifier.test_destroy
+          expect(modifier.versions.last.reify).to be_flagged_deleted
+        end
       end
+
     end
 
     context "when no argument" do


### PR DESCRIPTION
We're trying to upgrade our app to use the Rails 5.1 defaults, but we ran into a problem with PaperTrail. Specifically, when we try to soft delete certain records (i.e., mark them as deleted without actually deleting the row from the DB), and then try to make a change to the soft-deleted record, it raises an error saying the versions are invalid. This is because of the `belongs_to :item` on VersionConcern, which makes the association required with the new defaults. To stay compatible with the old way and allow deleting and soft deleting of records, we should make this association optional.

An unrelated commit adds the `rails-controller-testing` gem to the Gemfile. I tried adding it as a development dependency in the gemspec, but couldn't get it to work. Without this gem, a lot of the tests fail for me.