### PR TITLE
Fix ActiveRecord version check in Rails 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#988](https://github.com/airblade/paper_trail/pull/988) - Fix ActiveRecord
+  version check in `VersionConcern` for Rails 4.0
+
 
 ## 7.1.2 (2017-08-30)
 
@@ -31,9 +33,6 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [#985](https://github.com/airblade/paper_trail/pull/985) - Fix RecordInvalid
   error on nil item association when belongs_to_required_by_default is enabled.
-- [#988](https://github.com/airblade/paper_trail/pull/988) - Fix ActiveRecord
-  version check in `VersionConcern` for Rails 4.0
-
 ## 7.1.1 (2017-08-18)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [#985](https://github.com/airblade/paper_trail/pull/985) - Fix RecordInvalid
   error on nil item association when belongs_to_required_by_default is enabled.
+- [#988](https://github.com/airblade/paper_trail/pull/988) - Fix ActiveRecord
+  version check in `VersionConcern` for Rails 4.0
 
 ## 7.1.1 (2017-08-18)
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -1,6 +1,8 @@
 module PaperTrail
   # Represents the "paper trail" for a single record.
   class RecordTrail
+    # The respond_to? check here is specific to ActiveRecord 4.0 and can be
+    # removed when support for ActiveRecord < 4.2 is dropped.
     RAILS_GTE_5_1 = ::ActiveRecord.respond_to?(:gem_version) &&
       ::ActiveRecord.gem_version >= ::Gem::Version.new("5.1.0.beta1")
 

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -12,7 +12,8 @@ module PaperTrail
     extend ::ActiveSupport::Concern
 
     included do
-      if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+      if ::ActiveRecord.respond_to?(:gem_version) &&
+          ::ActiveRecord.gem_version >= Gem::Version.new("5.0")
         belongs_to :item, polymorphic: true, optional: true
       else
         belongs_to :item, polymorphic: true

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -12,6 +12,8 @@ module PaperTrail
     extend ::ActiveSupport::Concern
 
     included do
+      # The respond_to? check here is specific to ActiveRecord 4.0 and can be
+      # removed when support for ActiveRecord < 4.2 is dropped.
       if ::ActiveRecord.respond_to?(:gem_version) &&
           ::ActiveRecord.gem_version >= Gem::Version.new("5.0")
         belongs_to :item, polymorphic: true, optional: true


### PR DESCRIPTION
Rails 4.0 does not have the `ActiveRecord.gem_version` method, so this
check will fail there. However, we know that if `gem_version` is not
available, we are not dealing with Rails >= 5.0, so this will work in
both cases.

See #956 for an equivalent case elsewhere in the codebase.