### PR TITLE
Add whodunnit for with_versioning method in RSpec unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- [#990](https://github.com/airblade/paper_trail/pull/990) Add whodunnit for with_versioning method in RSpec unit tests
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1098,9 +1098,9 @@ Generates (but does not run) a migration to add a versions table.  Also generate
 
 As of version 6, PT no longer supports rails 3 or the [protected_attributes][17]
 gem. If you are still using them, you may use PT 5 or lower. We recommend
-upgrading to [strong_parameters][18] as soon as possible.  
+upgrading to [strong_parameters][18] as soon as possible.
 
-If you must use [protected_attributes][17] for now, and want to use PT > 5, you 
+If you must use [protected_attributes][17] for now, and want to use PT > 5, you
 can reopen `PaperTrail::Version` and add the following `attr_accessible` fields:
 
 ```ruby
@@ -1532,6 +1532,7 @@ require 'paper_trail/frameworks/rspec'
 ## 8. Integration with Other Libraries
 
 - [ActiveAdmin][42]
+- [RailsAdmin](https://github.com/sferik/rails_admin/wiki/Papertrail)
 - Sinatra - [paper_trail-sinatra][41]
 
 ## Articles

--- a/lib/paper_trail/frameworks/rspec/helpers.rb
+++ b/lib/paper_trail/frameworks/rspec/helpers.rb
@@ -4,12 +4,15 @@ module PaperTrail
       # Included in the RSpec configuration in `frameworks/rspec.rb`
       module InstanceMethods
         # enable versioning for specific blocks (at instance-level)
-        def with_versioning
+        def with_versioning(whodunnit: nil)
+          was_whodunnit = ::PaperTrail.whodunnit
           was_enabled = ::PaperTrail.enabled?
+          ::PaperTrail.whodunnit = whodunnit unless whodunnit.nil?
           ::PaperTrail.enabled = true
           yield
         ensure
           ::PaperTrail.enabled = was_enabled
+          ::PaperTrail.whodunnit = was_whodunnit unless whodunnit.nil?
         end
       end
 

--- a/spec/paper_trail_spec.rb
+++ b/spec/paper_trail_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe PaperTrail do
       end
     end
 
+    it "has whodunnit on in a `with_versioning` block" do
+      expect(described_class.whodunnit).to be_nil
+      with_versioning(whodunnit: "Not me") do
+        expect(described_class.whodunnit).to eq("Not me")
+      end
+      expect(described_class.whodunnit).to be_nil
+    end
+
     context "with block passed" do
       it "sets whodunnit only for the block passed" do
         described_class.whodunnit("foo") do


### PR DESCRIPTION
Added ability to set whodunnit in RSpec unit tests.

Use cases: service and model tests.