### PR TITLE
Lint: Fix various offenses, mostly rspec

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3,9 +3,6 @@ require: rubocop-rspec
 # Remove these configuration records
 # one by one as the offenses are removed from the code base.
 
-Lint/RescueWithoutErrorClass:
-  Enabled: false
-
 Metrics/AbcSize:
   Max: 22 # Goal: 15
 
@@ -22,12 +19,11 @@ RSpec/BeforeAfterAll:
   Enabled: false
 
 RSpec/ExpectInHook:
-  Enabled: false
+  Exclude:
+    - spec/paper_trail/associations_spec.rb
+    - spec/models/version_spec.rb
 
 RSpec/FilePath:
-  Enabled: false
-
-RSpec/HookArgument:
   Enabled: false
 
 RSpec/InstanceVariable:
@@ -35,11 +31,9 @@ RSpec/InstanceVariable:
     - spec/paper_trail/associations_spec.rb
     - spec/paper_trail/model_spec.rb
 
-RSpec/LetBeforeExamples:
-  Enabled: false
-
 RSpec/MessageSpies:
-  Enabled: false
+  Exclude:
+    - spec/models/version_spec.rb
 
 RSpec/NamedSubject:
   Enabled: false
@@ -48,9 +42,6 @@ RSpec/NestedGroups:
   Exclude:
     - spec/paper_trail/associations_spec.rb
     - spec/paper_trail/model_spec.rb
-
-RSpec/PredicateMatcher:
-  Enabled: false
 
 Security/YAMLLoad:
   Enabled: false

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -170,7 +170,7 @@ module PaperTrail
     def next_version
       subsequent_version = source_version.next
       subsequent_version ? subsequent_version.reify : @record.class.find(@record.id)
-    rescue # TODO: Rescue something more specific
+    rescue StandardError # TODO: Rescue something more specific
       nil
     end
 

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -162,7 +162,7 @@ module PaperTrail
 
       def primary_key_is_int?
         @primary_key_is_int ||= columns_hash[primary_key].type == :integer
-      rescue
+      rescue StandardError # TODO: Rescue something more specific
         true
       end
 
@@ -307,7 +307,7 @@ module PaperTrail
       else
         begin
           PaperTrail.serializer.load(object_changes)
-        rescue # TODO: Rescue something specific
+        rescue StandardError # TODO: Rescue something more specific
           {}
         end
       end

--- a/spec/models/gadget_spec.rb
+++ b/spec/models/gadget_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 RSpec.describe Gadget, type: :model do
-  it { is_expected.to be_versioned }
-
   let(:gadget) { Gadget.create!(name: "Wrench", brand: "Acme") }
+
+  it { is_expected.to be_versioned }
 
   describe "updates", versioning: true do
     it "generates a version for updates to `name` attribute" do

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -65,15 +65,16 @@ module PaperTrail
       it "sets the invoke `paper_trail_originator`" do
         allow(ActiveSupport::Deprecation).to receive(:warn)
         subject = PaperTrail::Version.new
-        expect(subject).to receive(:paper_trail_originator)
+        allow(subject).to receive(:paper_trail_originator)
         subject.originator
+        expect(subject).to have_received(:paper_trail_originator)
       end
 
       it "displays a deprecation warning" do
-        expect(ActiveSupport::Deprecation).to receive(:warn).
+        allow(ActiveSupport::Deprecation).to receive(:warn)
+        PaperTrail::Version.new.originator
+        expect(ActiveSupport::Deprecation).to have_received(:warn).
           with(/Use paper_trail_originator instead of originator/)
-        subject = PaperTrail::Version.new
-        subject.originator
       end
     end
 

--- a/spec/paper_trail/model_spec.rb
+++ b/spec/paper_trail/model_spec.rb
@@ -84,9 +84,9 @@ RSpec.describe(::PaperTrail, versioning: true) do
         end
 
         it "have versions that are not live" do
-          expect(
-            @widget.versions.map(&:reify).compact.all? { |w| !w.paper_trail.live? }
-          ).to(be_truthy)
+          @widget.versions.map(&:reify).compact.each do |v|
+            expect(v.paper_trail).not_to be_live
+          end
         end
 
         it "have stored changes" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
   # Truncation is about three times slower than transaction rollback, so it'll
   # be nice when we can drop support for rails < 5.
   if active_record_gem_version < ::Gem::Version.new("5")
-    config.before(:each) { DatabaseCleaner.start }
-    config.after(:each) { DatabaseCleaner.clean }
+    config.before { DatabaseCleaner.start }
+    config.after { DatabaseCleaner.clean }
   end
 end


### PR DESCRIPTION
- Fix Lint/RescueWithoutErrorClass
  - And I use the term "fix" loosely
- Fix RSpec/PredicateMatcher
  - The failure message should actually be better this way too.
- RSpec/LetBeforeExamples
- RSpec/HookArgument
- Fix RSpec/ExpectInHook in widget_spec.rb
- Fix RSpec/MessageSpies
  - I like spies. I've never linted them before, but I like how they
    separate test setup from assertions.