### PR TITLE
Drop support for ruby 2.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - spec/dummy_app/db/schema.rb # Generated, out of our control
 
   # Set to lowest supported version
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.4
-  - 2.1.10
+  - 2.4.2
+  - 2.2.8
 env:
   global:
     - TRAVIS=true
@@ -31,11 +31,6 @@ gemfile:
 
 matrix:
   fast_finish: true
-  exclude:
-    - gemfile: gemfiles/ar_5.0.gemfile
-      rvm: 2.1.10
-    - gemfile: gemfiles/ar_5.1.gemfile
-      rvm: 2.1.10
 
 addons:
   postgresql: "9.4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Breaking Changes
 
+- Drop support for ruby 2.1, whose EoL was 2017-04-01
 - [#803](https://github.com/airblade/paper_trail/issues/803) -
   where_object_changes no longer supports reading json from a text column
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ has been destroyed.
 
 | paper_trail    | branch     | tags   | ruby     | activerecord  |
 | -------------- | ---------- | ------ | -------- | ------------- |
-| unreleased     | master     |        | >= 2.1.0 | >= 4.0, < 6   |
+| unreleased     | master     |        | >= 2.2.0 | >= 4.2, < 6   |
 | 7              | 7-stable   | v7.x   | >= 2.1.0 | >= 4.0, < 6   |
 | 6              | 6-stable   | v6.x   | >= 1.9.3 | >= 4.0, < 6   |
 | 5              | 5-stable   | v5.x   | >= 1.9.3 | >= 3.0, < 5.1 |

--- a/doc/bug_report_template.rb
+++ b/doc/bug_report_template.rb
@@ -4,11 +4,11 @@ require "bundler/inline"
 
 # STEP ONE: What versions are you using?
 gemfile(true) do
-  ruby "2.3.1"
+  ruby "2.4.2"
   source "https://rubygems.org"
-  gem "activerecord", "5.0.0"
-  gem "minitest", "5.9.0"
-  gem "paper_trail", "5.2.0", require: false
+  gem "activerecord", "5.1.4"
+  gem "minitest", "5.10.3"
+  gem "paper_trail", "8.0.0", require: false
   gem "sqlite3"
 end
 

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -23,7 +23,7 @@ has been destroyed.
   s.require_paths = ["lib"]
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.2.0"
 
   # Rails does not follow semver, makes breaking changes in minor versions.
   s.add_dependency "activerecord", [">= 4.0", "< 5.2"]


### PR DESCRIPTION
Ruby 2.1 reached EoL on 2017-04-01.
https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/

PT continued to support it for 6 months after EoL.