### PR TITLE
Fix callback to only run before update

### DIFF
--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -59,7 +59,7 @@ module PaperTrail
 
     # Adds a callback that records a version after an "update" event.
     def on_update
-      @model_class.before_update { |r|
+      @model_class.before_save { |r|
         r.paper_trail.reset_timestamp_attrs_for_update_if_needed
       }
       @model_class.after_update { |r|

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -59,7 +59,7 @@ module PaperTrail
 
     # Adds a callback that records a version after an "update" event.
     def on_update
-      @model_class.before_save(on: :update) { |r|
+      @model_class.before_update { |r|
         r.paper_trail.reset_timestamp_attrs_for_update_if_needed
       }
       @model_class.after_update { |r|


### PR DESCRIPTION
`before_save` doesn't accept `:on` as an argument, so this callback was actually running on all save events, not just on update.

https://github.com/rails/rails/issues/17622

Depending on what `reset_timestamp_attrs_for_update_if_needed` does, this might need to be backported to older versions.

I've submitted a PR to Rails to raise an exception when unexpected arguments are passed... unsure if an exception is the right way to go when there might be quite a few gems with this bug.

https://github.com/rails/rails/pull/30919