### PR TITLE
Check for presence of Rails.env not just ::Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1003](https://github.com/airblade/paper_trail/pull/1003) - detect Rails
+  presence with `Rails.application` 
 
 ## 8.0.0 (2017-10-04)
 

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -187,7 +187,7 @@ ActiveSupport.on_load(:active_record) do
 end
 
 # Require frameworks
-if defined?(::Rails.env) && ActiveRecord::VERSION::STRING >= "3.2"
+if defined?(::Rails.application) && ActiveRecord::VERSION::STRING >= "3.2"
   require "paper_trail/frameworks/rails"
 else
   require "paper_trail/frameworks/active_record"

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -187,7 +187,7 @@ ActiveSupport.on_load(:active_record) do
 end
 
 # Require frameworks
-if defined?(::Rails) && ActiveRecord::VERSION::STRING >= "3.2"
+if defined?(::Rails.env) && ActiveRecord::VERSION::STRING >= "3.2"
   require "paper_trail/frameworks/rails"
 else
   require "paper_trail/frameworks/active_record"

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -187,6 +187,8 @@ ActiveSupport.on_load(:active_record) do
 end
 
 # Require frameworks
+# Rails module is sometimes opened by gems like rails-html-sanitizer 
+# so let's check for presence of Rails.application instead
 if defined?(::Rails.application) && ActiveRecord::VERSION::STRING >= "3.2"
   require "paper_trail/frameworks/rails"
 else


### PR DESCRIPTION
Sometimes Rails module is defined without Rails being loaded (e.g. rails-html-sanitizer defines this module). Instead let's check for Rails.env.

Solution taken from rails/activeresource#216