### PR TITLE
Print warning when PT cannot be loaded ..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1003](https://github.com/airblade/paper_trail/pull/1003) - Warn when PT
+  cannot be loaded because rails is not loaded yet.
 
 ## 8.0.0 (2017-10-04)
 


### PR DESCRIPTION
.. because rails is not loaded yet.

In some situations, when loading PT, `::Rails` has been defined,
perhaps by a library like rails-html-sanitizer, but rails itself
has not been loaded yet.

Supersedes https://github.com/airblade/paper_trail/pull/1003