### PR TITLE
End with newline created config/initializers/paper_trail.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ In PT 8, the following are deprecated, and will be removed in 9:
 - [#1009](https://github.com/airblade/paper_trail/pull/1009)
   End generated `config/initializers/paper_trail.rb` with newline.
 
-- None
-
 ## 8.0.1 (2017-10-25)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ In PT 8, the following are deprecated, and will be removed in 9:
 
 ### Fixed
 
+- [#1009](https://github.com/airblade/paper_trail/pull/1009)
+  End generated `config/initializers/paper_trail.rb` with newline.
+
 - None
 
 ## 8.0.1 (2017-10-25)

--- a/lib/generators/paper_trail/install_generator.rb
+++ b/lib/generators/paper_trail/install_generator.rb
@@ -43,7 +43,7 @@ module PaperTrail
     def create_initializer
       create_file(
         "config/initializers/paper_trail.rb",
-        "PaperTrail.config.track_associations = #{!!options.with_associations?}"
+        "PaperTrail.config.track_associations = #{!!options.with_associations?}\n"
       )
     end
 


### PR DESCRIPTION
Currently, config/initializers/paper_trail.rb file created by
    rails generate paper_trail:install
does not end with newline.
Such text files may result in trouble because in unix, because text files
generally should end with newline.

So, make it put newline at the end.