### PR TITLE
Improves performance for large datasets by outsourcing subselects

### DIFF
--- a/lib/paper_trail/reifiers/has_many_through.rb
+++ b/lib/paper_trail/reifiers/has_many_through.rb
@@ -72,7 +72,7 @@ module PaperTrail
         # @api private
         def load_versions_for_hmt_association(assoc, ids, tx_id, version_at)
           version_id_subquery = assoc.klass.paper_trail.version_class.
-            select("MIN(id)").
+            select("MIN(id) as min_id").
             where("item_type = ?", assoc.class_name).
             where("item_id IN (?)", ids).
             where(
@@ -80,8 +80,7 @@ module PaperTrail
               version_at,
               tx_id
             ).
-            group("item_id").
-            to_sql
+            group("item_id")
           Reifiers::HasMany.versions_by_id(assoc.klass, version_id_subquery)
         end
       end


### PR DESCRIPTION
On a dataset of ~300 000 entries, one query took about 20 seconds, which could be reduced, with the committed changes, to less than one ms.
This solution may cause problems when the subselect returns a large set of indices, therefore I tested this:
On the same dataset an query "SELECT * FROM versions WHERE ID in (30 000 different ids)" took about 112ms, but it was a direct sql statement so network latency is not included. But even if it were, it's still better than 20 seconds.

However, if the subselect returns 30 000 different ids, the versions table may be much larger than 300 000 entries and therefore even slower when using an subselect.
