### PR TITLE
Fix NameError when pg is not loaded

### DIFF
--- a/lib/paper_trail/attribute_serializers/attribute_serializer_factory.rb
+++ b/lib/paper_trail/attribute_serializers/attribute_serializer_factory.rb
@@ -7,10 +7,11 @@ module PaperTrail
     # replaces certain default Active Record serializers
     # with custom PaperTrail ones.
     module AttributeSerializerFactory
+      AR_PG_ARRAY_CLASS = "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array".freeze
+
       def self.for(klass, attr)
         active_record_serializer = klass.type_for_attribute(attr)
-        case active_record_serializer
-        when ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array then
+        if active_record_serializer.class.name == AR_PG_ARRAY_CLASS
           TypeSerializers::PostgresArraySerializer.new(
             active_record_serializer.subtype,
             active_record_serializer.delimiter


### PR DESCRIPTION
Most apps only load a single db adapter gem.

A MySQL app, for example will not load the pg gem.

See https://github.com/airblade/paper_trail/issues/1022