### PR TITLE
Use base class name for reification of associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
   error, was deprecated in 8.1.0.
 - Reifying associations will now use base class name instead of class name
   to reify STI models corrrectly.
+- Test will now use fractional second precision on datetime columns to enable
+  testing of versioned associations.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
   callbacks like `skip_after_action :warn_about_not_setting_whodunnit`.
 - Using where_object_changes to read YAML from a text column will now raise
   error, was deprecated in 8.1.0.
+- Reifying associations will now use base class name instead of class name
+  to reify STI models corrrectly.
 
 ### Added
 

--- a/lib/paper_trail/reifiers/belongs_to.rb
+++ b/lib/paper_trail/reifiers/belongs_to.rb
@@ -39,7 +39,7 @@ module PaperTrail
         # @api private
         def load_version(assoc, id, transaction_id, version_at)
           assoc.klass.paper_trail.version_class.
-            where("item_type = ?", assoc.klass.name).
+            where("item_type = ?", assoc.klass.base_class.name).
             where("item_id = ?", id).
             where("created_at >= ? OR transaction_id = ?", version_at, transaction_id).
             order("id").limit(1).first

--- a/lib/paper_trail/reifiers/has_and_belongs_to_many.rb
+++ b/lib/paper_trail/reifiers/has_and_belongs_to_many.rb
@@ -39,7 +39,7 @@ module PaperTrail
         # @api private
         def load_version(assoc, id, transaction_id, version_at)
           assoc.klass.paper_trail.version_class.
-            where("item_type = ?", assoc.klass.name).
+            where("item_type = ?", assoc.klass.base_class.name).
             where("item_id = ?", id).
             where("created_at >= ? OR transaction_id = ?", version_at, transaction_id).
             order("id").

--- a/lib/paper_trail/reifiers/has_many.rb
+++ b/lib/paper_trail/reifiers/has_many.rb
@@ -100,7 +100,7 @@ module PaperTrail
             select("MIN(version_id)").
             where("foreign_key_name = ?", assoc.foreign_key).
             where("foreign_key_id = ?", model.id).
-            where("#{version_table}.item_type = ?", assoc.klass.name).
+            where("#{version_table}.item_type = ?", assoc.klass.base_class.name).
             where("created_at >= ? OR transaction_id = ?", version_at, tx_id).
             group("item_id").
             to_sql

--- a/lib/paper_trail/reifiers/has_many_through.rb
+++ b/lib/paper_trail/reifiers/has_many_through.rb
@@ -75,7 +75,7 @@ module PaperTrail
         def load_versions_for_hmt_association(assoc, ids, tx_id, version_at)
           version_id_subquery = assoc.klass.paper_trail.version_class.
             select("MIN(id)").
-            where("item_type = ?", assoc.klass.name).
+            where("item_type = ?", assoc.klass.base_class.name).
             where("item_id IN (?)", ids).
             where(
               "created_at >= ? OR transaction_id = ?",

--- a/lib/paper_trail/reifiers/has_one.rb
+++ b/lib/paper_trail/reifiers/has_one.rb
@@ -38,7 +38,7 @@ module PaperTrail
           model.class.paper_trail.version_class.joins(:version_associations).
             where("version_associations.foreign_key_name = ?", assoc.foreign_key).
             where("version_associations.foreign_key_id = ?", model.id).
-            where("#{version_table_name}.item_type = ?", assoc.klass.name).
+            where("#{version_table_name}.item_type = ?", assoc.klass.base_class.name).
             where("created_at >= ? OR transaction_id = ?", version_at, transaction_id).
             order("#{version_table_name}.id ASC").
             first

--- a/spec/dummy_app/app/models/bicycle.rb
+++ b/spec/dummy_app/app/models/bicycle.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Bicycle < Vehicle
+  has_paper_trail
+end

--- a/spec/dummy_app/app/models/person.rb
+++ b/spec/dummy_app/app/models/person.rb
@@ -4,6 +4,14 @@ class Person < ActiveRecord::Base
   has_many :authorships, foreign_key: :author_id, dependent: :destroy
   has_many :books, through: :authorships
 
+  has_many :pets, foreign_key: :owner_id, dependent: :destroy
+  has_many :animals, through: :pets
+  has_many :dogs, class_name: "Dog", through: :pets, source: :animal
+  has_many :cats, class_name: "Cat", through: :pets, source: :animal
+
+  has_one :car, foreign_key: :owner_id
+  has_one :bicycle, foreign_key: :owner_id
+
   if ActiveRecord.gem_version >= Gem::Version.new("5.0")
     belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id, optional: true
   else

--- a/spec/dummy_app/app/models/person.rb
+++ b/spec/dummy_app/app/models/person.rb
@@ -18,6 +18,12 @@ class Person < ActiveRecord::Base
     belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id
   end
 
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :vehicle, class_name: "Vehicle", foreign_key: :vehicle_id, optional: true
+  else
+    belongs_to :vehicle, class_name: "Vehicle", foreign_key: :vehicle_id
+  end
+
   has_paper_trail
 
   # Convert strings to TimeZone objects when assigned

--- a/spec/dummy_app/app/models/pet.rb
+++ b/spec/dummy_app/app/models/pet.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Pet < ActiveRecord::Base
+  belongs_to :owner, class_name: "Person"
+  belongs_to :animal
+
+  has_paper_trail
+end

--- a/spec/dummy_app/app/models/pet.rb
+++ b/spec/dummy_app/app/models/pet.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 class Pet < ActiveRecord::Base
-  belongs_to :owner, class_name: "Person"
-  belongs_to :animal
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :owner, class_name: "Person", optional: true
+  else
+    belongs_to :owner, class_name: "Person"
+  end
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :animal, optional: true
+  else
+    belongs_to :animal
+  end
 
   has_paper_trail
 end

--- a/spec/dummy_app/app/models/truck.rb
+++ b/spec/dummy_app/app/models/truck.rb
@@ -2,5 +2,5 @@
 
 class Truck < Vehicle
   # This STI child class specifically does not call `has_paper_trail`.
-  # Of the sub-classes of `Vehicle`, only `Car` is versioned.
+  # Of the sub-classes of `Vehicle`, only `Car` and `Bicycle` are versioned.
 end

--- a/spec/dummy_app/app/models/vehicle.rb
+++ b/spec/dummy_app/app/models/vehicle.rb
@@ -2,5 +2,11 @@
 
 class Vehicle < ActiveRecord::Base
   # This STI parent class specifically does not call `has_paper_trail`.
-  # Of its sub-classes, only `Car` is versioned.
+  # Of its sub-classes, only `Car` and `Bicycle` are versioned.
+
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :owner, class_name: "Person", optional: true
+  else
+    belongs_to :owner, class_name: "Person"
+  end
 end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -41,13 +41,13 @@ class SetUpTestTables < (
       t.string :name, null: false
       t.string :type, null: false
       t.integer :owner_id
-      t.timestamps null: false
+      t.timestamps null: false, limit: 6
     end
 
     create_table :skippers, force: true do |t|
       t.string     :name
       t.datetime   :another_timestamp, limit: 6
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :widgets, force: true do |t|
@@ -61,7 +61,7 @@ class SetUpTestTables < (
       t.date      :a_date
       t.boolean   :a_boolean
       t.string    :type
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     if ENV["DB"] == "postgres"
@@ -69,7 +69,7 @@ class SetUpTestTables < (
         t.string     :name
         t.integer    :post_ids,    array: true
         t.datetime   :login_times, array: true, limit: 6
-        t.timestamps null: true
+        t.timestamps null: true, limit: 6
       end
     end
 
@@ -134,11 +134,11 @@ class SetUpTestTables < (
     end
 
     create_table :not_on_updates, force: true do |t|
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :bananas, force: true do |t|
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :banana_versions, force: true do |t|
@@ -154,7 +154,7 @@ class SetUpTestTables < (
     create_table :wotsits, force: true do |t|
       t.integer :widget_id
       t.string  :name
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :fluxors, force: true do |t|
@@ -210,7 +210,7 @@ class SetUpTestTables < (
 
     create_table :post_with_statuses, force: true do |t|
       t.integer :status
-      t.timestamps null: false
+      t.timestamps null: false, limit: 6
     end
 
     create_table :animals, force: true do |t|
@@ -246,7 +246,7 @@ class SetUpTestTables < (
     create_table :gadgets, force: true do |t|
       t.string    :name
       t.string    :brand
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :customers, force: true do |t|
@@ -319,7 +319,7 @@ class SetUpTestTables < (
     create_table :custom_primary_key_records, id: false, force: true do |t|
       t.column :uuid, :string, primary_key: true
       t.string :name
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     # and custom_primary_key_record_versions stores the uuid in item_id, a string

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -40,6 +40,7 @@ class SetUpTestTables < (
     create_table :vehicles, force: true do |t|
       t.string :name, null: false
       t.string :type, null: false
+      t.integer :owner_id
       t.timestamps null: false
     end
 
@@ -215,6 +216,11 @@ class SetUpTestTables < (
     create_table :animals, force: true do |t|
       t.string :name
       t.string :species # single table inheritance column
+    end
+
+    create_table :pets, force: true do |t|
+      t.integer :owner_id
+      t.integer :animal_id
     end
 
     create_table :documents, force: true do |t|

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -36,7 +36,7 @@ class SetUpTestTables < (
       t.string :name, null: false
     end
 
-    # Classes: Vehicle, Car, Truck
+    # Classes: Vehicle, Car, Bicycle, Truck
     create_table :vehicles, force: true do |t|
       t.string :name, null: false
       t.string :type, null: false
@@ -46,7 +46,7 @@ class SetUpTestTables < (
 
     create_table :skippers, force: true do |t|
       t.string     :name
-      t.datetime   :another_timestamp
+      t.datetime   :another_timestamp, limit: 6
       t.timestamps null: true
     end
 
@@ -56,7 +56,7 @@ class SetUpTestTables < (
       t.integer   :an_integer
       t.float     :a_float
       t.decimal   :a_decimal, precision: 6, scale: 4
-      t.datetime  :a_datetime
+      t.datetime  :a_datetime, limit: 6
       t.time      :a_time
       t.date      :a_date
       t.boolean   :a_boolean
@@ -68,7 +68,7 @@ class SetUpTestTables < (
       create_table :postgres_users, force: true do |t|
         t.string     :name
         t.integer    :post_ids,    array: true
-        t.datetime   :login_times, array: true
+        t.datetime   :login_times, array: true, limit: 6
         t.timestamps null: true
       end
     end
@@ -81,7 +81,7 @@ class SetUpTestTables < (
       t.text     :object, limit: TEXT_BYTES
       t.text     :object_changes, limit: TEXT_BYTES
       t.integer  :transaction_id
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
 
       # Metadata columns.
       t.integer :answer
@@ -112,7 +112,7 @@ class SetUpTestTables < (
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
 
       # Controller info columns.
       t.string :ip
@@ -128,7 +128,7 @@ class SetUpTestTables < (
         t.string   :whodunnit
         t.json     :object
         t.json     :object_changes
-        t.datetime :created_at
+        t.datetime :created_at, limit: 6
       end
       add_index :json_versions, %i[item_type item_id]
     end
@@ -147,7 +147,7 @@ class SetUpTestTables < (
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
     end
     add_index :banana_versions, %i[item_type item_id]
 
@@ -329,7 +329,7 @@ class SetUpTestTables < (
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
     end
     add_index :custom_primary_key_record_versions, %i[item_type item_id], name: "idx_cust_pk_item"
 

--- a/spec/dummy_app/db/schema.rb
+++ b/spec/dummy_app/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: 6
     t.index ["item_type", "item_id"], name: "index_banana_versions_on_item_type_and_item_id"
   end
 
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: 6
     t.index ["item_type", "item_id"], name: "idx_cust_pk_item"
   end
 
@@ -201,7 +201,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: 6
     t.string "ip"
     t.string "user_agent"
     t.index ["item_type", "item_id"], name: "index_post_versions_on_item_type_and_item_id"
@@ -229,7 +229,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
 
   create_table "skippers", force: :cascade do |t|
     t.string "name"
-    t.datetime "another_timestamp"
+    t.datetime "another_timestamp", precision: 6
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -252,6 +252,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   create_table "vehicles", force: :cascade do |t|
     t.string "name", null: false
     t.string "type", null: false
+    t.integer "owner_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -272,7 +273,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.text "object", limit: 1073741823
     t.text "object_changes", limit: 1073741823
     t.integer "transaction_id"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: 6
     t.integer "answer"
     t.string "action"
     t.string "question"
@@ -295,7 +296,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.integer "an_integer"
     t.float "a_float"
     t.decimal "a_decimal", precision: 6, scale: 4
-    t.datetime "a_datetime"
+    t.datetime "a_datetime", precision: 6
     t.time "a_time"
     t.date "a_date"
     t.boolean "a_boolean"

--- a/spec/dummy_app/db/schema.rb
+++ b/spec/dummy_app/db/schema.rb
@@ -190,6 +190,11 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.integer "mentor_id"
   end
 
+  create_table "pets", force: :cascade do |t|
+    t.integer "owner_id"
+    t.integer "animal_id"
+  end
+
   create_table "post_versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false

--- a/spec/dummy_app/db/schema.rb
+++ b/spec/dummy_app/db/schema.rb
@@ -40,8 +40,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   end
 
   create_table "bananas", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "bar_habtms", force: :cascade do |t|
@@ -89,9 +89,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
 
   create_table "custom_primary_key_records", primary_key: "uuid", id: :string, force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["uuid"], unique: true
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "customers", force: :cascade do |t|
@@ -139,8 +138,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   create_table "gadgets", force: :cascade do |t|
     t.string "name"
     t.string "brand"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "legacy_widgets", force: :cascade do |t|
@@ -154,8 +153,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   end
 
   create_table "not_on_updates", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "on_create", force: :cascade do |t|
@@ -209,8 +208,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
 
   create_table "post_with_statuses", force: :cascade do |t|
     t.integer "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "posts", force: :cascade do |t|
@@ -230,8 +229,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   create_table "skippers", force: :cascade do |t|
     t.string "name"
     t.datetime "another_timestamp", precision: 6
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "songs", force: :cascade do |t|
@@ -253,8 +252,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "name", null: false
     t.string "type", null: false
     t.integer "owner_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "version_associations", force: :cascade do |t|
@@ -301,15 +300,15 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.date "a_date"
     t.boolean "a_boolean"
     t.string "type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "wotsits", force: :cascade do |t|
     t.integer "widget_id"
     t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
 end

--- a/spec/dummy_app/db/schema.rb
+++ b/spec/dummy_app/db/schema.rb
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
 
   create_table "custom_primary_key_records", primary_key: "uuid", id: :string, force: :cascade do |t|
     t.string "name"
+    t.index ["uuid"], unique: true
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Person, type: :model, versioning: true do
+  it "baseline test setup" do
+    expect(Person.new).to be_versioned
+  end
+
+  describe "#cars and bicycles" do
+    it "can be reified", skip: "Known Issue #594" do
+      person = Person.create(name: "Frank")
+      car = Car.create(name: "BMW 325")
+      bicycle = Bicycle.create(name: "BMX 1.0")
+
+      person.car = car
+      person.bicycle = bicycle
+      person.update_attributes(name: "Steve")
+
+      car.update_attributes(name: "BMW 330")
+      bicycle.update_attributes(name: "BMX 2.0")
+      person.update_attributes(name: "Peter")
+
+      expect(person.reload.versions.length).to(eq(3))
+
+      # Will fail because the correct sub type of the STI model is not present at query.
+      # See https://github.com/airblade/paper_trail/issues/594
+      second_version = person.reload.versions.second.reify(has_one: true)
+      expect(second_version.car.name).to(eq("BMW 325"))
+      expect(second_version.bicycle.name).to(eq("BMX 1.0"))
+    end
+  end
+end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pet, type: :model, versioning: true do
+  it "baseline test setup" do
+    expect(Pet.new).to be_versioned
+  end
+
+  it "can be reified" do
+    person = Person.create(name: "Frank")
+    dog = Dog.create(name: "Snoopy")
+    cat = Cat.create(name: "Garfield")
+
+    person.pets << Pet.create(animal: dog)
+    person.pets << Pet.create(animal: cat)
+    person.update_attributes(name: "Steve")
+
+    dog.update_attributes(name: "Beethoven")
+    cat.update_attributes(name: "Sylvester")
+    person.update_attributes(name: "Peter")
+
+    expect(person.reload.versions.length).to(eq(3))
+
+    second_version = person.reload.versions.second.reify(has_many: true)
+    expect(second_version.pets.length).to(eq(2))
+    expect(second_version.animals.length).to(eq(2))
+    expect(second_version.animals.map { |a| a.class.name }).to(eq(%w[Dog Cat]))
+    expect(second_version.pets.map { |p| p.animal.class.name }).to(eq(%w[Dog Cat]))
+    expect(second_version.animals.first.name).to(eq("Snoopy"))
+    expect(second_version.dogs.first.name).to(eq("Snoopy"))
+    expect(second_version.animals.second.name).to(eq("Garfield"))
+    expect(second_version.cats.first.name).to(eq("Garfield"))
+
+    last_version = person.reload.versions.last.reify(has_many: true)
+    expect(last_version.pets.length).to(eq(2))
+    expect(last_version.animals.length).to(eq(2))
+    expect(last_version.animals.map { |a| a.class.name }).to(eq(%w[Dog Cat]))
+    expect(last_version.pets.map { |p| p.animal.class.name }).to(eq(%w[Dog Cat]))
+    expect(last_version.animals.first.name).to(eq("Beethoven"))
+    expect(last_version.dogs.first.name).to(eq("Beethoven"))
+    expect(last_version.animals.second.name).to(eq("Sylvester"))
+    expect(last_version.cats.first.name).to(eq("Sylvester"))
+  end
+end


### PR DESCRIPTION
Use base class name for reification instead of class name to reify polymorphic models properly.

Refers to #594 but won´t fix all issues. If you have more `has_one` associations to an polymorphic model you won´t get the correct associated models because sub type reference is missing in query.