### PR TITLE
Use base class name for reification and add fractional second precision to test db

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,6 +13,13 @@ On github, we appreciate bug reports, feature suggestions, and pull requests.
 
 Please use our [bug report template][1].
 
+## Reporting Security Vulnerabilities
+
+Please email jared@jaredbeck.com, batkinz@gmail.com
+
+We will respond as soon as we can. Thank you for responsibly disclosing
+security vulnerabilities.
+
 ## Development
 
 Install gems with `bundle exec appraisal install`.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,13 @@
 Thanks for your interest in PaperTrail! Our volunteers' time is limited, so we
-can only respond on GitHub to bug reports and feature requests. Please ask
-*usage questions* on StackOverflow (https://stackoverflow.com/tags/paper-trail-gem)
-so that the whole community has a chance to answer your question.
+can only respond on GitHub to *bug reports* and *feature requests*.
 
-Please use our template
-(https://github.com/airblade/paper_trail/blob/master/doc/bug_report_template.rb)
-when reporting bugs.
+Please ask *usage questions* on StackOverflow:
+https://stackoverflow.com/tags/paper-trail-gem
 
-For other questions, please see our contributing guide.
-(https://github.com/airblade/paper_trail/blob/master/.github/CONTRIBUTING.md)
+Bug reports must use this template:
+https://github.com/airblade/paper_trail/blob/master/doc/bug_report_template.rb
+
+For other questions, please see our contributing guide:
+https://github.com/airblade/paper_trail/blob/master/.github/CONTRIBUTING.md
 
 Thanks for your contribution!

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - spec/dummy_app/db/schema.rb # Generated, out of our control
 
   # Set to lowest supported version
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,13 +12,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 9 # Goal: 7
 
-# Switching to frozen strings internally would be fine, but if any of those
-# frozen strings cross our public API, that would be a breaking change.
-# Let's wait until we drop support for ruby 2.2 before doing this. If we freeze
-# before dropping 2.2, the comment could be misleading.
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 RSpec/InstanceVariable:
   Exclude:
     - spec/paper_trail/associations_spec.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.4.2
-  - 2.2.8
+  - 2.3.5
 env:
   global:
     - TRAVIS=true

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Specify here only version constraints that differ from
 # `paper_trail.gemspec`.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
   callbacks like `skip_after_action :warn_about_not_setting_whodunnit`.
 - Using where_object_changes to read YAML from a text column will now raise
   error, was deprecated in 8.1.0.
+- Tests will now use fractional second precision on datetime columns to
+  enable testing of versioned associations.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
   error, was deprecated in 8.1.0.
 - Tests will now use fractional second precision on datetime columns to
   enable testing of versioned associations.
+- Reifying associations will now use base class name instead of class name
+  to reify STI models corrrectly.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Breaking Changes
 
-- [#479](https://github.com/airblade/paper_trail/issues/479) - Deprecated
-  `originator` method, use `paper_trail_originator`
+- Drop support for ruby 2.2, [whose EoL is the end of March,
+  2018](https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/)
+- Assume that all strings returned by PaperTrail are frozen.
+- Removed deprecated `Version#originator`, use `#paper_trail_originator`
 - Using paper_trail.on_destroy(:after) with ActiveRecord's
   belongs_to_required_by_default will produce an error instead of a warning.
 - Failing to set PaperTrail.config.track_associations will no longer produce
   a warning. The default (false) will remain the same.
-- The `warn_about_not_setting_whodunnit` controller method will be removed.
-  Remove callbacks like `skip_after_action :warn_about_not_setting_whodunnit`.
-- [#997](https://github.com/airblade/paper_trail/pull/997) -
-  where_object_changes reading YAML from a text column
+- Removed `warn_about_not_setting_whodunnit` controller method. Please remove
+  callbacks like `skip_after_action :warn_about_not_setting_whodunnit`.
+- Using where_object_changes to read YAML from a text column will now raise
+  error, was deprecated in 8.1.0.
 
 ### Added
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler"
 Bundler::GemHelper.install_tasks
 

--- a/doc/bug_report_template.rb
+++ b/doc/bug_report_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Use this template to report PaperTrail bugs.
 # Please include only the minimum code necessary to reproduce your issue.
 require "bundler/inline"

--- a/lib/generators/paper_trail/install_generator.rb
+++ b/lib/generators/paper_trail/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/generators"
 require "rails/generators/active_record"
 

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 require "request_store"
 require "paper_trail/cleaner"
@@ -156,7 +158,7 @@ module PaperTrail
 
     # @api public
     def transaction?
-      ::ActiveRecord::Base.connection.open_transactions > 0
+      ::ActiveRecord::Base.connection.open_transactions.positive?
     end
 
     # @api public

--- a/lib/paper_trail/attribute_serializers/attribute_serializer_factory.rb
+++ b/lib/paper_trail/attribute_serializers/attribute_serializer_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "paper_trail/type_serializers/postgres_array_serializer"
 
 module PaperTrail
@@ -7,7 +9,7 @@ module PaperTrail
     # replaces certain default Active Record serializers
     # with custom PaperTrail ones.
     module AttributeSerializerFactory
-      AR_PG_ARRAY_CLASS = "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array".freeze
+      AR_PG_ARRAY_CLASS = "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array"
 
       def self.for(klass, attr)
         active_record_serializer = klass.type_for_attribute(attr)

--- a/lib/paper_trail/attribute_serializers/cast_attribute_serializer.rb
+++ b/lib/paper_trail/attribute_serializers/cast_attribute_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "paper_trail/attribute_serializers/attribute_serializer_factory"
 
 module PaperTrail

--- a/lib/paper_trail/attribute_serializers/object_attribute.rb
+++ b/lib/paper_trail/attribute_serializers/object_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "paper_trail/attribute_serializers/cast_attribute_serializer"
 
 module PaperTrail

--- a/lib/paper_trail/attribute_serializers/object_changes_attribute.rb
+++ b/lib/paper_trail/attribute_serializers/object_changes_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "paper_trail/attribute_serializers/cast_attribute_serializer"
 
 module PaperTrail

--- a/lib/paper_trail/cleaner.rb
+++ b/lib/paper_trail/cleaner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   # Utilities for deleting version records.
   module Cleaner

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "singleton"
 require "paper_trail/serializers/yaml"
 
@@ -18,18 +20,17 @@ module PaperTrail
       @serializer = PaperTrail::Serializers::YAML
     end
 
-    # Previously, we checked `PaperTrail::VersionAssociation.table_exists?`
+    # As of PaperTrail 5, `track_associations?` defaults to false. Tracking
+    # associations is an experimental feature so we recommend setting
+    # PaperTrail.config.track_associations = false in your
+    # config/initializers/paper_trail.rb
+    #
+    # In PT 4, we checked `PaperTrail::VersionAssociation.table_exists?`
     # here, but that proved to be problematic in situations when the database
     # connection had not been established, or when the database does not exist
     # yet (as with `rake db:create`).
     def track_associations?
       if @track_associations.nil?
-        ActiveSupport::Deprecation.warn <<-EOS.strip_heredoc.gsub(/\s+/, " ")
-          PaperTrail.config.track_associations has not been set. As of PaperTrail 5, it
-          defaults to false. Tracking associations is an experimental feature so
-          we recommend setting PaperTrail.config.track_associations = false in
-          your config/initializers/paper_trail.rb
-        EOS
         false
       else
         @track_associations

--- a/lib/paper_trail/frameworks/active_record.rb
+++ b/lib/paper_trail/frameworks/active_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file only needs to be loaded if the gem is being used outside of Rails,
 # since otherwise the model(s) will get loaded in via the `Rails::Engine`.
 require "paper_trail/frameworks/active_record/models/paper_trail/version_association"

--- a/lib/paper_trail/frameworks/active_record/models/paper_trail/version.rb
+++ b/lib/paper_trail/frameworks/active_record/models/paper_trail/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "paper_trail/version_concern"
 
 module PaperTrail

--- a/lib/paper_trail/frameworks/active_record/models/paper_trail/version_association.rb
+++ b/lib/paper_trail/frameworks/active_record/models/paper_trail/version_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "paper_trail/version_association_concern"
 
 module PaperTrail

--- a/lib/paper_trail/frameworks/cucumber.rb
+++ b/lib/paper_trail/frameworks/cucumber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # before hook for Cucumber
 Before do
   PaperTrail.enabled = false

--- a/lib/paper_trail/frameworks/rails.rb
+++ b/lib/paper_trail/frameworks/rails.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "paper_trail/frameworks/rails/controller"
 require "paper_trail/frameworks/rails/engine"

--- a/lib/paper_trail/frameworks/rails/controller.rb
+++ b/lib/paper_trail/frameworks/rails/controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Rails
     # Extensions to rails controllers. Provides convenient ways to pass certain
@@ -77,16 +79,6 @@ module PaperTrail
         if ::PaperTrail.enabled_for_controller?
           ::PaperTrail.controller_info = info_for_paper_trail
         end
-      end
-
-      # We have removed this warning. We no longer add it as a callback.
-      # However, some people use `skip_after_action :warn_about_not_setting_whodunnit`,
-      # so removing this method would be a breaking change. We can remove it
-      # in the next major version.
-      def warn_about_not_setting_whodunnit
-        ::ActiveSupport::Deprecation.warn(
-          "warn_about_not_setting_whodunnit is a no-op and is deprecated."
-        )
       end
     end
   end

--- a/lib/paper_trail/frameworks/rails/engine.rb
+++ b/lib/paper_trail/frameworks/rails/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Rails
     # See http://guides.rubyonrails.org/engines.html

--- a/lib/paper_trail/frameworks/rspec.rb
+++ b/lib/paper_trail/frameworks/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/core"
 require "rspec/matchers"
 require "paper_trail/frameworks/rspec/helpers"

--- a/lib/paper_trail/frameworks/rspec/helpers.rb
+++ b/lib/paper_trail/frameworks/rspec/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module RSpec
     module Helpers

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/object" # provides the `try` method
 require "paper_trail/attribute_serializers/object_attribute"
 require "paper_trail/attribute_serializers/object_changes_attribute"

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext"
 
 module PaperTrail
@@ -6,7 +8,7 @@ module PaperTrail
   class ModelConfig
     E_CANNOT_RECORD_AFTER_DESTROY = <<-STR.strip_heredoc.freeze
       paper_trail.on_destroy(:after) is incompatible with ActiveRecord's
-      belongs_to_required_by_default and has no effect. Please use :before
+      belongs_to_required_by_default. Use on_destroy(:before)
       or disable belongs_to_required_by_default.
     STR
 
@@ -45,7 +47,7 @@ module PaperTrail
       end
 
       if recording_order.to_s == "after" && cannot_record_after_destroy?
-        ::ActiveSupport::Deprecation.warn(E_CANNOT_RECORD_AFTER_DESTROY)
+        raise E_CANNOT_RECORD_AFTER_DESTROY
       end
 
       @model_class.send(

--- a/lib/paper_trail/queries/versions/where_object.rb
+++ b/lib/paper_trail/queries/versions/where_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Queries
     module Versions

--- a/lib/paper_trail/queries/versions/where_object_changes.rb
+++ b/lib/paper_trail/queries/versions/where_object_changes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Queries
     module Versions

--- a/lib/paper_trail/record_history.rb
+++ b/lib/paper_trail/record_history.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   # Represents the history of a single record.
   # @api private

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   # Represents the "paper trail" for a single record.
   class RecordTrail
@@ -500,7 +502,7 @@ module PaperTrail
     end
 
     def log_version_errors(version, action)
-      version.logger && version.logger.warn(
+      version.logger&.warn(
         "Unable to create version for #{action} of #{@record.class.name}" +
           "##{@record.id}: " + version.errors.full_messages.join(", ")
       )

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "paper_trail/attribute_serializers/object_attribute"
 require "paper_trail/reifiers/belongs_to"
 require "paper_trail/reifiers/has_and_belongs_to_many"

--- a/lib/paper_trail/reifiers/belongs_to.rb
+++ b/lib/paper_trail/reifiers/belongs_to.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Reifiers
     # Reify a single `belongs_to` association of `model`.

--- a/lib/paper_trail/reifiers/belongs_to.rb
+++ b/lib/paper_trail/reifiers/belongs_to.rb
@@ -39,7 +39,7 @@ module PaperTrail
         # @api private
         def load_version(assoc, id, transaction_id, version_at)
           assoc.klass.paper_trail.version_class.
-            where("item_type = ?", assoc.klass.name).
+            where("item_type = ?", assoc.klass.base_class.name).
             where("item_id = ?", id).
             where("created_at >= ? OR transaction_id = ?", version_at, transaction_id).
             order("id").limit(1).first

--- a/lib/paper_trail/reifiers/has_and_belongs_to_many.rb
+++ b/lib/paper_trail/reifiers/has_and_belongs_to_many.rb
@@ -39,7 +39,7 @@ module PaperTrail
         # @api private
         def load_version(assoc, id, transaction_id, version_at)
           assoc.klass.paper_trail.version_class.
-            where("item_type = ?", assoc.klass.name).
+            where("item_type = ?", assoc.klass.base_class.name).
             where("item_id = ?", id).
             where("created_at >= ? OR transaction_id = ?", version_at, transaction_id).
             order("id").

--- a/lib/paper_trail/reifiers/has_and_belongs_to_many.rb
+++ b/lib/paper_trail/reifiers/has_and_belongs_to_many.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Reifiers
     # Reify a single HABTM association of `model`.

--- a/lib/paper_trail/reifiers/has_many.rb
+++ b/lib/paper_trail/reifiers/has_many.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Reifiers
     # Reify a single, direct (not `through`) `has_many` association of `model`.

--- a/lib/paper_trail/reifiers/has_many.rb
+++ b/lib/paper_trail/reifiers/has_many.rb
@@ -100,7 +100,7 @@ module PaperTrail
             select("MIN(version_id)").
             where("foreign_key_name = ?", assoc.foreign_key).
             where("foreign_key_id = ?", model.id).
-            where("#{version_table}.item_type = ?", assoc.klass.name).
+            where("#{version_table}.item_type = ?", assoc.klass.base_class.name).
             where("created_at >= ? OR transaction_id = ?", version_at, tx_id).
             group("item_id").
             to_sql

--- a/lib/paper_trail/reifiers/has_many_through.rb
+++ b/lib/paper_trail/reifiers/has_many_through.rb
@@ -75,7 +75,7 @@ module PaperTrail
         def load_versions_for_hmt_association(assoc, ids, tx_id, version_at)
           version_id_subquery = assoc.klass.paper_trail.version_class.
             select("MIN(id)").
-            where("item_type = ?", assoc.klass.name).
+            where("item_type = ?", assoc.klass.base_class.name).
             where("item_id IN (?)", ids).
             where(
               "created_at >= ? OR transaction_id = ?",

--- a/lib/paper_trail/reifiers/has_many_through.rb
+++ b/lib/paper_trail/reifiers/has_many_through.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Reifiers
     # Reify a single HMT association of `model`.

--- a/lib/paper_trail/reifiers/has_one.rb
+++ b/lib/paper_trail/reifiers/has_one.rb
@@ -38,7 +38,7 @@ module PaperTrail
           model.class.paper_trail.version_class.joins(:version_associations).
             where("version_associations.foreign_key_name = ?", assoc.foreign_key).
             where("version_associations.foreign_key_id = ?", model.id).
-            where("#{version_table_name}.item_type = ?", assoc.klass.name).
+            where("#{version_table_name}.item_type = ?", assoc.klass.base_class.name).
             where("created_at >= ? OR transaction_id = ?", version_at, transaction_id).
             order("#{version_table_name}.id ASC").
             first

--- a/lib/paper_trail/reifiers/has_one.rb
+++ b/lib/paper_trail/reifiers/has_one.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module Reifiers
     # Reify a single `has_one` association of `model`.

--- a/lib/paper_trail/serializers/json.rb
+++ b/lib/paper_trail/serializers/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/json"
 
 module PaperTrail
@@ -34,7 +36,7 @@ module PaperTrail
 
       def where_object_changes_condition(*)
         raise <<-STR.squish.freeze
-          where_object_changes no longer supports reading json from a text
+          where_object_changes no longer supports reading JSON from a text
           column. The old implementation was inaccurate, returning more records
           than you wanted. This feature was deprecated in 7.1.0 and removed in
           8.0.0. The json and jsonb datatypes are still supported. See the

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -1,16 +1,11 @@
+# frozen_string_literal: true
+
 require "yaml"
 
 module PaperTrail
   module Serializers
     # The default serializer for, e.g. `versions.object`.
     module YAML
-      E_WHERE_OBJ_CHANGES = <<-STR.squish.freeze
-        where_object_changes has a known issue. When reading YAML from a text
-        column, it may return more records than expected. Instead of a warning,
-        this method may raise an error in the future. Please join the discussion
-        at https://github.com/airblade/paper_trail/pull/997
-      STR
-
       extend self # makes all instance methods become module methods as well
 
       def load(string)
@@ -29,13 +24,14 @@ module PaperTrail
 
       # Returns a SQL LIKE condition to be used to match the given field and
       # value in the serialized `object_changes`.
-      def where_object_changes_condition(arel_field, field, value)
-        ::ActiveSupport::Deprecation.warn(E_WHERE_OBJ_CHANGES)
-
-        # Need to check first (before) and secondary (after) fields
-        m1 = "%\n#{field}:\n- #{value}\n%"
-        m2 = "%\n#{field}:\n-%\n- #{value}\n%"
-        arel_field.matches(m1).or(arel_field.matches(m2))
+      def where_object_changes_condition(*)
+        raise <<-STR.squish.freeze
+          where_object_changes no longer supports reading YAML from a text
+          column. The old implementation was inaccurate, returning more records
+          than you wanted. This feature was deprecated in 8.1.0 and removed in
+          9.0.0. The json and jsonb datatypes are still supported. See
+          discussion at https://github.com/airblade/paper_trail/pull/997
+        STR
       end
     end
   end

--- a/lib/paper_trail/type_serializers/postgres_array_serializer.rb
+++ b/lib/paper_trail/type_serializers/postgres_array_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   module TypeSerializers
     # Provides an alternative method of serialization

--- a/lib/paper_trail/version_association_concern.rb
+++ b/lib/paper_trail/version_association_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/concern"
 
 module PaperTrail

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/concern"
 require "paper_trail/attribute_serializers/object_changes_attribute"
 require "paper_trail/queries/versions/where_object"
@@ -228,11 +230,6 @@ module PaperTrail
     # Returns who put the item into the state stored in this version.
     def paper_trail_originator
       @paper_trail_originator ||= previous.try(:whodunnit)
-    end
-
-    def originator
-      ::ActiveSupport::Deprecation.warn "Use paper_trail_originator instead of originator."
-      paper_trail_originator
     end
 
     # Returns who changed the item from the state it had in this version. This

--- a/lib/paper_trail/version_number.rb
+++ b/lib/paper_trail/version_number.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PaperTrail
   # The version number of the paper_trail gem. Not to be confused with
   # `PaperTrail::Version`. Ruby constants are case-sensitive, apparently,

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -15,7 +15,7 @@ has been destroyed.
   EOS
   s.homepage = "https://github.com/airblade/paper_trail"
   s.authors = ["Andy Stewart", "Ben Atkins", "Jared Beck"]
-  s.email = "batkinz@gmail.com"
+  s.email = "jared@jaredbeck.com"
   s.license = "MIT"
 
   s.files = `git ls-files -z`.split("\x0").select { |f|

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "paper_trail/version_number"
 
@@ -23,7 +25,7 @@ has been destroyed.
   s.require_paths = ["lib"]
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   # Rails does not follow semver, makes breaking changes in minor versions.
   s.add_dependency "activerecord", [">= 4.2", "< 5.2"]

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe ArticlesController, type: :controller do

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe WidgetsController, type: :controller, versioning: true do

--- a/spec/dummy_app/Rakefile
+++ b/spec/dummy_app/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/spec/dummy_app/app/controllers/application_controller.rb
+++ b/spec/dummy_app/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery
 

--- a/spec/dummy_app/app/controllers/articles_controller.rb
+++ b/spec/dummy_app/app/controllers/articles_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ArticlesController < ApplicationController
   def create
     @article = Article.create article_params

--- a/spec/dummy_app/app/controllers/test_controller.rb
+++ b/spec/dummy_app/app/controllers/test_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestController < ActionController::Base
   def user_for_paper_trail
     Thread.current.object_id

--- a/spec/dummy_app/app/controllers/widgets_controller.rb
+++ b/spec/dummy_app/app/controllers/widgets_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WidgetsController < ApplicationController
   def paper_trail_enabled_for_controller
     request.user_agent != "Disable User-Agent"

--- a/spec/dummy_app/app/models/animal.rb
+++ b/spec/dummy_app/app/models/animal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Animal < ActiveRecord::Base
   has_paper_trail
   self.inheritance_column = "species"

--- a/spec/dummy_app/app/models/article.rb
+++ b/spec/dummy_app/app/models/article.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Demonstrates the `only` and `ignore` attributes, among other things.
 class Article < ActiveRecord::Base
   has_paper_trail(

--- a/spec/dummy_app/app/models/authorship.rb
+++ b/spec/dummy_app/app/models/authorship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Authorship < ActiveRecord::Base
   belongs_to :book
   belongs_to :author, class_name: "Person"

--- a/spec/dummy_app/app/models/bar_habtm.rb
+++ b/spec/dummy_app/app/models/bar_habtm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BarHabtm < ActiveRecord::Base
   has_and_belongs_to_many :foo_habtms
   has_paper_trail

--- a/spec/dummy_app/app/models/bicycle.rb
+++ b/spec/dummy_app/app/models/bicycle.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Bicycle < Vehicle
+  has_paper_trail
+end

--- a/spec/dummy_app/app/models/book.rb
+++ b/spec/dummy_app/app/models/book.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Book < ActiveRecord::Base
   has_many :authorships, dependent: :destroy
   has_many :authors, through: :authorships

--- a/spec/dummy_app/app/models/boolit.rb
+++ b/spec/dummy_app/app/models/boolit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Boolit < ActiveRecord::Base
   default_scope { where(scoped: true) }
   has_paper_trail

--- a/spec/dummy_app/app/models/callback_modifier.rb
+++ b/spec/dummy_app/app/models/callback_modifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CallbackModifier < ActiveRecord::Base
   has_paper_trail on: []
 

--- a/spec/dummy_app/app/models/car.rb
+++ b/spec/dummy_app/app/models/car.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Car < Vehicle
   has_paper_trail
 end

--- a/spec/dummy_app/app/models/cat.rb
+++ b/spec/dummy_app/app/models/cat.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Cat < Animal
 end

--- a/spec/dummy_app/app/models/chapter.rb
+++ b/spec/dummy_app/app/models/chapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Chapter < ActiveRecord::Base
   has_many :sections, dependent: :destroy
   has_many :paragraphs, through: :sections

--- a/spec/dummy_app/app/models/citation.rb
+++ b/spec/dummy_app/app/models/citation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Citation < ActiveRecord::Base
   belongs_to :quotation
 

--- a/spec/dummy_app/app/models/custom_primary_key_record.rb
+++ b/spec/dummy_app/app/models/custom_primary_key_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "securerandom"
 
 class CustomPrimaryKeyRecord < ActiveRecord::Base

--- a/spec/dummy_app/app/models/customer.rb
+++ b/spec/dummy_app/app/models/customer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Customer < ActiveRecord::Base
   has_many :orders, dependent: :destroy
   has_paper_trail

--- a/spec/dummy_app/app/models/document.rb
+++ b/spec/dummy_app/app/models/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Demonstrates a "custom versions association name". Instead of the assication
 # being named `versions`, it will be named `paper_trail_versions`.
 class Document < ActiveRecord::Base

--- a/spec/dummy_app/app/models/dog.rb
+++ b/spec/dummy_app/app/models/dog.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Dog < Animal
 end

--- a/spec/dummy_app/app/models/editor.rb
+++ b/spec/dummy_app/app/models/editor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # to demonstrate a has_through association that does not have paper_trail enabled
 class Editor < ActiveRecord::Base
   has_many :editorships, dependent: :destroy

--- a/spec/dummy_app/app/models/editorship.rb
+++ b/spec/dummy_app/app/models/editorship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Editorship < ActiveRecord::Base
   belongs_to :book
   belongs_to :editor

--- a/spec/dummy_app/app/models/elephant.rb
+++ b/spec/dummy_app/app/models/elephant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Elephant < Animal
   paper_trail.disable
 end

--- a/spec/dummy_app/app/models/family/family.rb
+++ b/spec/dummy_app/app/models/family/family.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Family
   class Family < ActiveRecord::Base
     has_paper_trail

--- a/spec/dummy_app/app/models/family/family_line.rb
+++ b/spec/dummy_app/app/models/family/family_line.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Family
   class FamilyLine < ActiveRecord::Base
     has_paper_trail

--- a/spec/dummy_app/app/models/fluxor.rb
+++ b/spec/dummy_app/app/models/fluxor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Fluxor < ActiveRecord::Base
   if ActiveRecord.gem_version >= Gem::Version.new("5.0")
     belongs_to :widget, optional: true

--- a/spec/dummy_app/app/models/foo_habtm.rb
+++ b/spec/dummy_app/app/models/foo_habtm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FooHabtm < ActiveRecord::Base
   has_and_belongs_to_many :bar_habtms
   accepts_nested_attributes_for :bar_habtms

--- a/spec/dummy_app/app/models/foo_widget.rb
+++ b/spec/dummy_app/app/models/foo_widget.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class FooWidget < Widget
 end

--- a/spec/dummy_app/app/models/fruit.rb
+++ b/spec/dummy_app/app/models/fruit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Fruit < ActiveRecord::Base
   if ENV["DB"] == "postgres" || JsonVersion.table_exists?
     has_paper_trail class_name: "JsonVersion"

--- a/spec/dummy_app/app/models/gadget.rb
+++ b/spec/dummy_app/app/models/gadget.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Gadget < ActiveRecord::Base
   has_paper_trail ignore: :brand
 end

--- a/spec/dummy_app/app/models/kitchen/banana.rb
+++ b/spec/dummy_app/app/models/kitchen/banana.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kitchen
   class Banana < ActiveRecord::Base
     has_paper_trail class_name: "Kitchen::BananaVersion"

--- a/spec/dummy_app/app/models/legacy_widget.rb
+++ b/spec/dummy_app/app/models/legacy_widget.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The `legacy_widgets` table has a `version` column that would conflict with our
 # `version` method. It is configured to define a method named `custom_version`
 # instead.

--- a/spec/dummy_app/app/models/line_item.rb
+++ b/spec/dummy_app/app/models/line_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LineItem < ActiveRecord::Base
   belongs_to :order, dependent: :destroy
   has_paper_trail

--- a/spec/dummy_app/app/models/not_on_update.rb
+++ b/spec/dummy_app/app/models/not_on_update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This model does not record versions when updated.
 class NotOnUpdate < ActiveRecord::Base
   has_paper_trail on: %i[create destroy]

--- a/spec/dummy_app/app/models/on/create.rb
+++ b/spec/dummy_app/app/models/on/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module On
   class Create < ActiveRecord::Base
     self.table_name = :on_create

--- a/spec/dummy_app/app/models/on/destroy.rb
+++ b/spec/dummy_app/app/models/on/destroy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module On
   class Destroy < ActiveRecord::Base
     self.table_name = :on_destroy

--- a/spec/dummy_app/app/models/on/empty_array.rb
+++ b/spec/dummy_app/app/models/on/empty_array.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module On
   class EmptyArray < ActiveRecord::Base
     self.table_name = :on_empty_array

--- a/spec/dummy_app/app/models/on/update.rb
+++ b/spec/dummy_app/app/models/on/update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module On
   class Update < ActiveRecord::Base
     self.table_name = :on_update

--- a/spec/dummy_app/app/models/order.rb
+++ b/spec/dummy_app/app/models/order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Order < ActiveRecord::Base
   belongs_to :customer
   has_many :line_items

--- a/spec/dummy_app/app/models/paragraph.rb
+++ b/spec/dummy_app/app/models/paragraph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Paragraph < ActiveRecord::Base
   belongs_to :section
 

--- a/spec/dummy_app/app/models/person.rb
+++ b/spec/dummy_app/app/models/person.rb
@@ -4,10 +4,24 @@ class Person < ActiveRecord::Base
   has_many :authorships, foreign_key: :author_id, dependent: :destroy
   has_many :books, through: :authorships
 
+  has_many :pets, foreign_key: :owner_id, dependent: :destroy
+  has_many :animals, through: :pets
+  has_many :dogs, class_name: "Dog", through: :pets, source: :animal
+  has_many :cats, class_name: "Cat", through: :pets, source: :animal
+
+  has_one :car, foreign_key: :owner_id
+  has_one :bicycle, foreign_key: :owner_id
+
   if ActiveRecord.gem_version >= Gem::Version.new("5.0")
     belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id, optional: true
   else
     belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id
+  end
+
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :vehicle, class_name: "Vehicle", foreign_key: :vehicle_id, optional: true
+  else
+    belongs_to :vehicle, class_name: "Vehicle", foreign_key: :vehicle_id
   end
 
   has_paper_trail

--- a/spec/dummy_app/app/models/person.rb
+++ b/spec/dummy_app/app/models/person.rb
@@ -18,12 +18,6 @@ class Person < ActiveRecord::Base
     belongs_to :mentor, class_name: "Person", foreign_key: :mentor_id
   end
 
-  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
-    belongs_to :vehicle, class_name: "Vehicle", foreign_key: :vehicle_id, optional: true
-  else
-    belongs_to :vehicle, class_name: "Vehicle", foreign_key: :vehicle_id
-  end
-
   has_paper_trail
 
   # Convert strings to TimeZone objects when assigned

--- a/spec/dummy_app/app/models/person.rb
+++ b/spec/dummy_app/app/models/person.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Person < ActiveRecord::Base
   has_many :authorships, foreign_key: :author_id, dependent: :destroy
   has_many :books, through: :authorships

--- a/spec/dummy_app/app/models/pet.rb
+++ b/spec/dummy_app/app/models/pet.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-class Vehicle < ActiveRecord::Base
-  # This STI parent class specifically does not call `has_paper_trail`.
-  # Of its sub-classes, only `Car` and `Bicycle` are versioned.
-
+class Pet < ActiveRecord::Base
   if ActiveRecord.gem_version >= Gem::Version.new("5.0")
     belongs_to :owner, class_name: "Person", optional: true
   else
     belongs_to :owner, class_name: "Person"
   end
+  if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+    belongs_to :animal, optional: true
+  else
+    belongs_to :animal
+  end
+
+  has_paper_trail
 end

--- a/spec/dummy_app/app/models/post.rb
+++ b/spec/dummy_app/app/models/post.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Post < ActiveRecord::Base
   has_paper_trail class_name: "PostVersion"
 end

--- a/spec/dummy_app/app/models/post_with_status.rb
+++ b/spec/dummy_app/app/models/post_with_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This model tests ActiveRecord::Enum, which was added in AR 4.1
 # http://edgeguides.rubyonrails.org/4_1_release_notes.html#active-record-enums
 class PostWithStatus < ActiveRecord::Base

--- a/spec/dummy_app/app/models/quotation.rb
+++ b/spec/dummy_app/app/models/quotation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Quotation < ActiveRecord::Base
   belongs_to :chapter
   has_many :citations, dependent: :destroy

--- a/spec/dummy_app/app/models/section.rb
+++ b/spec/dummy_app/app/models/section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Section < ActiveRecord::Base
   belongs_to :chapter
   has_many :paragraphs, dependent: :destroy

--- a/spec/dummy_app/app/models/skipper.rb
+++ b/spec/dummy_app/app/models/skipper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Skipper < ActiveRecord::Base
   has_paper_trail ignore: [:created_at], skip: [:another_timestamp]
 end

--- a/spec/dummy_app/app/models/song.rb
+++ b/spec/dummy_app/app/models/song.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OverrideSongAttributesTheRails4Way
   def attributes
     if name

--- a/spec/dummy_app/app/models/thing.rb
+++ b/spec/dummy_app/app/models/thing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Thing < ActiveRecord::Base
   has_paper_trail save_changes: false
 end

--- a/spec/dummy_app/app/models/translation.rb
+++ b/spec/dummy_app/app/models/translation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Demonstrates the `if` and `unless` configuration options.
 class Translation < ActiveRecord::Base
   # Has a `type` column, but it's not used for STI.

--- a/spec/dummy_app/app/models/truck.rb
+++ b/spec/dummy_app/app/models/truck.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Truck < Vehicle
   # This STI child class specifically does not call `has_paper_trail`.
   # Of the sub-classes of `Vehicle`, only `Car` is versioned.

--- a/spec/dummy_app/app/models/truck.rb
+++ b/spec/dummy_app/app/models/truck.rb
@@ -2,5 +2,5 @@
 
 class Truck < Vehicle
   # This STI child class specifically does not call `has_paper_trail`.
-  # Of the sub-classes of `Vehicle`, only `Car` is versioned.
+  # Of the sub-classes of `Vehicle`, only `Car` and `Bicycle` are versioned.
 end

--- a/spec/dummy_app/app/models/user.rb
+++ b/spec/dummy_app/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PostgresUser < ActiveRecord::Base
   has_paper_trail
 end

--- a/spec/dummy_app/app/models/vehicle.rb
+++ b/spec/dummy_app/app/models/vehicle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Vehicle < ActiveRecord::Base
   # This STI parent class specifically does not call `has_paper_trail`.
   # Of its sub-classes, only `Car` is versioned.

--- a/spec/dummy_app/app/models/whatchamajigger.rb
+++ b/spec/dummy_app/app/models/whatchamajigger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Whatchamajigger < ActiveRecord::Base
   has_paper_trail
 

--- a/spec/dummy_app/app/models/widget.rb
+++ b/spec/dummy_app/app/models/widget.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Widget < ActiveRecord::Base
-  EXCLUDED_NAME = "Biglet".freeze
+  EXCLUDED_NAME = "Biglet"
   has_paper_trail
   has_one :wotsit
   has_many(:fluxors, -> { order(:name) })

--- a/spec/dummy_app/app/models/wotsit.rb
+++ b/spec/dummy_app/app/models/wotsit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Wotsit < ActiveRecord::Base
   has_paper_trail
 

--- a/spec/dummy_app/app/versions/custom_primary_key_record_version.rb
+++ b/spec/dummy_app/app/versions/custom_primary_key_record_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CustomPrimaryKeyRecordVersion < PaperTrail::Version
   self.table_name = "custom_primary_key_record_versions"
 end

--- a/spec/dummy_app/app/versions/joined_version.rb
+++ b/spec/dummy_app/app/versions/joined_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The purpose of this custom version class is to test the scope methods on the
 # VersionConcern::ClassMethods module. See
 # https://github.com/airblade/paper_trail/issues/295 for more details.

--- a/spec/dummy_app/app/versions/json_version.rb
+++ b/spec/dummy_app/app/versions/json_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsonVersion < PaperTrail::Version
   self.table_name = "json_versions"
 end

--- a/spec/dummy_app/app/versions/kitchen/banana_version.rb
+++ b/spec/dummy_app/app/versions/kitchen/banana_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kitchen
   class BananaVersion < PaperTrail::Version
     self.table_name = "banana_versions"

--- a/spec/dummy_app/app/versions/post_version.rb
+++ b/spec/dummy_app/app/versions/post_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PostVersion < PaperTrail::Version
   self.table_name = "post_versions"
 end

--- a/spec/dummy_app/config.ru
+++ b/spec/dummy_app/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path("../config/environment", __FILE__)

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../boot", __FILE__)
 
 # Pick the frameworks you want:

--- a/spec/dummy_app/config/boot.rb
+++ b/spec/dummy_app/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems"
 
 # When you run rake locally (not on travis) in this dummy app, set the

--- a/spec/dummy_app/config/environment.rb
+++ b/spec/dummy_app/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the rails application
 require File.expand_path("../application", __FILE__)
 

--- a/spec/dummy_app/config/environments/development.rb
+++ b/spec/dummy_app/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/spec/dummy_app/config/environments/production.rb
+++ b/spec/dummy_app/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/spec/dummy_app/config/environments/test.rb
+++ b/spec/dummy_app/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/spec/dummy_app/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy_app/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish

--- a/spec/dummy_app/config/initializers/inflections.rb
+++ b/spec/dummy_app/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/spec/dummy_app/config/initializers/mime_types.rb
+++ b/spec/dummy_app/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/spec/dummy_app/config/initializers/paper_trail.rb
+++ b/spec/dummy_app/config/initializers/paper_trail.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 PaperTrail.config.track_associations = true

--- a/spec/dummy_app/config/initializers/secret_token.rb
+++ b/spec/dummy_app/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.

--- a/spec/dummy_app/config/initializers/session_store.rb
+++ b/spec/dummy_app/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: "_dummy_session"

--- a/spec/dummy_app/config/routes.rb
+++ b/spec/dummy_app/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.routes.draw do
   resources :articles, only: [:create]
   resources :widgets, only: %i[create update destroy]

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -40,6 +40,7 @@ class SetUpTestTables < (
     create_table :vehicles, force: true do |t|
       t.string :name, null: false
       t.string :type, null: false
+      t.integer :owner_id
       t.timestamps null: false, limit: 6
     end
 
@@ -215,6 +216,11 @@ class SetUpTestTables < (
     create_table :animals, force: true do |t|
       t.string :name
       t.string :species # single table inheritance column
+    end
+
+    create_table :pets, force: true do |t|
+      t.integer :owner_id
+      t.integer :animal_id
     end
 
     create_table :documents, force: true do |t|

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Parts of this migration must be kept in sync with
 # `lib/generators/paper_trail/templates/create_versions.rb`
 #

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -40,13 +40,13 @@ class SetUpTestTables < (
     create_table :vehicles, force: true do |t|
       t.string :name, null: false
       t.string :type, null: false
-      t.timestamps null: false
+      t.timestamps null: false, limit: 6
     end
 
     create_table :skippers, force: true do |t|
       t.string     :name
-      t.datetime   :another_timestamp
-      t.timestamps null: true
+      t.datetime   :another_timestamp, limit: 6
+      t.timestamps null: true, limit: 6
     end
 
     create_table :widgets, force: true do |t|
@@ -55,20 +55,20 @@ class SetUpTestTables < (
       t.integer   :an_integer
       t.float     :a_float
       t.decimal   :a_decimal, precision: 6, scale: 4
-      t.datetime  :a_datetime
+      t.datetime  :a_datetime, limit: 6
       t.time      :a_time
       t.date      :a_date
       t.boolean   :a_boolean
       t.string    :type
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     if ENV["DB"] == "postgres"
       create_table :postgres_users, force: true do |t|
         t.string     :name
         t.integer    :post_ids,    array: true
-        t.datetime   :login_times, array: true
-        t.timestamps null: true
+        t.datetime   :login_times, array: true, limit: 6
+        t.timestamps null: true, limit: 6
       end
     end
 
@@ -80,7 +80,7 @@ class SetUpTestTables < (
       t.text     :object, limit: TEXT_BYTES
       t.text     :object_changes, limit: TEXT_BYTES
       t.integer  :transaction_id
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
 
       # Metadata columns.
       t.integer :answer
@@ -111,7 +111,7 @@ class SetUpTestTables < (
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
 
       # Controller info columns.
       t.string :ip
@@ -127,17 +127,17 @@ class SetUpTestTables < (
         t.string   :whodunnit
         t.json     :object
         t.json     :object_changes
-        t.datetime :created_at
+        t.datetime :created_at, limit: 6
       end
       add_index :json_versions, %i[item_type item_id]
     end
 
     create_table :not_on_updates, force: true do |t|
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :bananas, force: true do |t|
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :banana_versions, force: true do |t|
@@ -146,14 +146,14 @@ class SetUpTestTables < (
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
     end
     add_index :banana_versions, %i[item_type item_id]
 
     create_table :wotsits, force: true do |t|
       t.integer :widget_id
       t.string  :name
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :fluxors, force: true do |t|
@@ -209,7 +209,7 @@ class SetUpTestTables < (
 
     create_table :post_with_statuses, force: true do |t|
       t.integer :status
-      t.timestamps null: false
+      t.timestamps null: false, limit: 6
     end
 
     create_table :animals, force: true do |t|
@@ -240,7 +240,7 @@ class SetUpTestTables < (
     create_table :gadgets, force: true do |t|
       t.string    :name
       t.string    :brand
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     create_table :customers, force: true do |t|
@@ -313,7 +313,7 @@ class SetUpTestTables < (
     create_table :custom_primary_key_records, id: false, force: true do |t|
       t.column :uuid, :string, primary_key: true
       t.string :name
-      t.timestamps null: true
+      t.timestamps null: true, limit: 6
     end
 
     # and custom_primary_key_record_versions stores the uuid in item_id, a string
@@ -323,7 +323,7 @@ class SetUpTestTables < (
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object
-      t.datetime :created_at
+      t.datetime :created_at, limit: 6
     end
     add_index :custom_primary_key_record_versions, %i[item_type item_id], name: "idx_cust_pk_item"
 

--- a/spec/dummy_app/db/schema.rb
+++ b/spec/dummy_app/db/schema.rb
@@ -35,13 +35,13 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", limit: 6
     t.index ["item_type", "item_id"], name: "index_banana_versions_on_item_type_and_item_id"
   end
 
   create_table "bananas", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", limit: 6
+    t.datetime "updated_at", limit: 6
   end
 
   create_table "bar_habtms", force: :cascade do |t|
@@ -83,15 +83,15 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", limit: 6
     t.index ["item_type", "item_id"], name: "idx_cust_pk_item"
   end
 
   create_table "custom_primary_key_records", primary_key: "uuid", id: :string, force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
     t.index ["uuid"], unique: true
+    t.datetime "created_at", limit: 6
+    t.datetime "updated_at", limit: 6
   end
 
   create_table "customers", force: :cascade do |t|
@@ -139,8 +139,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   create_table "gadgets", force: :cascade do |t|
     t.string "name"
     t.string "brand"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", limit: 6
+    t.datetime "updated_at", limit: 6
   end
 
   create_table "legacy_widgets", force: :cascade do |t|
@@ -154,8 +154,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   end
 
   create_table "not_on_updates", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", limit: 6
+    t.datetime "updated_at", limit: 6
   end
 
   create_table "on_create", force: :cascade do |t|
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
-    t.datetime "created_at"
+    t.datetime "created_at", limit: 6
     t.string "ip"
     t.string "user_agent"
     t.index ["item_type", "item_id"], name: "index_post_versions_on_item_type_and_item_id"
@@ -204,8 +204,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
 
   create_table "post_with_statuses", force: :cascade do |t|
     t.integer "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", null: false, limit: 6
+    t.datetime "updated_at", null: false, limit: 6
   end
 
   create_table "posts", force: :cascade do |t|
@@ -224,9 +224,9 @@ ActiveRecord::Schema.define(version: 20110208155312) do
 
   create_table "skippers", force: :cascade do |t|
     t.string "name"
-    t.datetime "another_timestamp"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "another_timestamp", limit: 6
+    t.datetime "created_at", limit: 6
+    t.datetime "updated_at", limit: 6
   end
 
   create_table "songs", force: :cascade do |t|
@@ -247,8 +247,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   create_table "vehicles", force: :cascade do |t|
     t.string "name", null: false
     t.string "type", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", null: false, limit: 6
+    t.datetime "updated_at", null: false, limit: 6
   end
 
   create_table "version_associations", force: :cascade do |t|
@@ -267,7 +267,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.text "object", limit: 1073741823
     t.text "object_changes", limit: 1073741823
     t.integer "transaction_id"
-    t.datetime "created_at"
+    t.datetime "created_at", limit: 6
     t.integer "answer"
     t.string "action"
     t.string "question"
@@ -290,20 +290,20 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.integer "an_integer"
     t.float "a_float"
     t.decimal "a_decimal", precision: 6, scale: 4
-    t.datetime "a_datetime"
+    t.datetime "a_datetime", limit: 6
     t.time "a_time"
     t.date "a_date"
     t.boolean "a_boolean"
     t.string "type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", limit: 6
+    t.datetime "updated_at", limit: 6
   end
 
   create_table "wotsits", force: :cascade do |t|
     t.integer "widget_id"
     t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", limit: 6
+    t.datetime "updated_at", limit: 6
   end
 
 end

--- a/spec/dummy_app/db/schema.rb
+++ b/spec/dummy_app/db/schema.rb
@@ -190,6 +190,11 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.integer "mentor_id"
   end
 
+  create_table "pets", force: :cascade do |t|
+    t.integer "owner_id"
+    t.integer "animal_id"
+  end
+
   create_table "post_versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
@@ -247,6 +252,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
   create_table "vehicles", force: :cascade do |t|
     t.string "name", null: false
     t.string "type", null: false
+    t.integer "owner_id"
     t.datetime "created_at", null: false, limit: 6
     t.datetime "updated_at", null: false, limit: 6
   end

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "generator_spec/test_case"
 require File.expand_path("../../../../lib/generators/paper_trail/install_generator", __FILE__)

--- a/spec/models/animal_spec.rb
+++ b/spec/models/animal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Animal, type: :model, versioning: true do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Article, type: :model, versioning: true do

--- a/spec/models/boolit_spec.rb
+++ b/spec/models/boolit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/custom_json_serializer"
 

--- a/spec/models/callback_modifier_spec.rb
+++ b/spec/models/callback_modifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe CallbackModifier, type: :model, versioning: true do

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Car, type: :model do

--- a/spec/models/custom_primary_key_record_spec.rb
+++ b/spec/models/custom_primary_key_record_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe CustomPrimaryKeyRecord, type: :model do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Document, type: :model, versioning: true do
@@ -6,17 +8,6 @@ RSpec.describe Document, type: :model, versioning: true do
       document = Document.create!(name: "Foo")
       document.update_attributes!(name: "Bar")
       expect(document).to have_a_version_with(name: "Foo")
-    end
-  end
-
-  describe "have_a_version_with_changes matcher" do
-    it "works with custom versions association" do
-      document = Document.create!(name: "Foo")
-      document.update_attributes!(name: "Bar")
-      allow(ActiveSupport::Deprecation).to receive(:warn)
-      expect(document).to have_a_version_with_changes(name: "Bar")
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
-        once.with(/^where_object_changes/)
     end
   end
 

--- a/spec/models/family/family_spec.rb
+++ b/spec/models/family/family_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module Family

--- a/spec/models/fruit_spec.rb
+++ b/spec/models/fruit_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+if ENV["DB"] == "postgres" || JsonVersion.table_exists?
+  RSpec.describe Fruit, type: :model, versioning: true do
+    describe "have_a_version_with_changes matcher" do
+      it "works with Fruit because Fruit uses JsonVersion" do
+        # As of PT 9.0.0, with_version_changes only supports json(b) columns,
+        # so that's why were testing the have_a_version_with_changes matcher
+        # here.
+        banana = Fruit.create!(color: "Red", name: "Banana")
+        banana.update_attributes!(color: "Yellow")
+        expect(banana).to have_a_version_with_changes(color: "Yellow")
+        expect(banana).not_to have_a_version_with_changes(color: "Pink")
+        expect(banana).not_to have_a_version_with_changes(color: "Yellow", name: "Kiwi")
+      end
+    end
+  end
+end

--- a/spec/models/gadget_spec.rb
+++ b/spec/models/gadget_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Gadget, type: :model do

--- a/spec/models/joined_version_spec.rb
+++ b/spec/models/joined_version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe JoinedVersion, type: :model, versioning: true do

--- a/spec/models/json_version_spec.rb
+++ b/spec/models/json_version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 # The `json_versions` table tests postgres' `json` data type. So, that

--- a/spec/models/kitchen/banana_spec.rb
+++ b/spec/models/kitchen/banana_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module Kitchen

--- a/spec/models/legacy_widget_spec.rb
+++ b/spec/models/legacy_widget_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe LegacyWidget, type: :model, versioning: true do

--- a/spec/models/not_on_update_spec.rb
+++ b/spec/models/not_on_update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe NotOnUpdate, type: :model do

--- a/spec/models/on/create_spec.rb
+++ b/spec/models/on/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_dependency "on/create"
 

--- a/spec/models/on/destroy_spec.rb
+++ b/spec/models/on/destroy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_dependency "on/destroy"
 

--- a/spec/models/on/empty_array_spec.rb
+++ b/spec/models/on/empty_array_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_dependency "on/empty_array"
 

--- a/spec/models/on/update_spec.rb
+++ b/spec/models/on/update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_dependency "on/update"
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Person, type: :model, versioning: true do
+  it "baseline test setup" do
+    expect(Person.new).to be_versioned
+  end
+
+  describe "#cars and bicycles" do
+    it "can be reified", skip: "Known Issue #594" do
+      person = Person.create(name: "Frank")
+      car = Car.create(name: "BMW 325")
+      bicycle = Bicycle.create(name: "BMX 1.0")
+
+      person.car = car
+      person.bicycle = bicycle
+      person.update_attributes(name: "Steve")
+
+      car.update_attributes(name: "BMW 330")
+      bicycle.update_attributes(name: "BMX 2.0")
+      person.update_attributes(name: "Peter")
+
+      expect(person.reload.versions.length).to(eq(3))
+
+      # Will fail because the correct sub type of the STI model is not present at query.
+      # See https://github.com/airblade/paper_trail/issues/594
+      second_version = person.reload.versions.second.reify(has_one: true)
+      expect(second_version.car.name).to(eq("BMW 325"))
+      expect(second_version.bicycle.name).to(eq("BMX 1.0"))
+    end
+  end
+end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pet, type: :model, versioning: true do
+  it "baseline test setup" do
+    expect(Pet.new).to be_versioned
+  end
+
+  it "can be reified" do
+    person = Person.create(name: "Frank")
+    dog = Dog.create(name: "Snoopy")
+    cat = Cat.create(name: "Garfield")
+
+    person.pets << Pet.create(animal: dog)
+    person.pets << Pet.create(animal: cat)
+    person.update_attributes(name: "Steve")
+
+    dog.update_attributes(name: "Beethoven")
+    cat.update_attributes(name: "Sylvester")
+    person.update_attributes(name: "Peter")
+
+    expect(person.reload.versions.length).to(eq(3))
+
+    second_version = person.reload.versions.second.reify(has_many: true)
+    expect(second_version.pets.length).to(eq(2))
+    expect(second_version.animals.length).to(eq(2))
+    expect(second_version.animals.map { |a| a.class.name }).to(eq(%w[Dog Cat]))
+    expect(second_version.pets.map { |p| p.animal.class.name }).to(eq(%w[Dog Cat]))
+    expect(second_version.animals.first.name).to(eq("Snoopy"))
+    expect(second_version.dogs.first.name).to(eq("Snoopy"))
+    expect(second_version.animals.second.name).to(eq("Garfield"))
+    expect(second_version.cats.first.name).to(eq("Garfield"))
+
+    last_version = person.reload.versions.last.reify(has_many: true)
+    expect(last_version.pets.length).to(eq(2))
+    expect(last_version.animals.length).to(eq(2))
+    expect(last_version.animals.map { |a| a.class.name }).to(eq(%w[Dog Cat]))
+    expect(last_version.pets.map { |p| p.animal.class.name }).to(eq(%w[Dog Cat]))
+    expect(last_version.animals.first.name).to(eq("Beethoven"))
+    expect(last_version.dogs.first.name).to(eq("Beethoven"))
+    expect(last_version.animals.second.name).to(eq("Sylvester"))
+    expect(last_version.cats.first.name).to(eq("Sylvester"))
+  end
+end

--- a/spec/models/post_with_status_spec.rb
+++ b/spec/models/post_with_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe PostWithStatus, type: :model do

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Skipper, type: :model, versioning: true do

--- a/spec/models/thing_spec.rb
+++ b/spec/models/thing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Thing, type: :model do

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Translation, type: :model, versioning: true do

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Vehicle, type: :model do

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail
@@ -62,23 +64,6 @@ module PaperTrail
           widget.update_attributes!(name: FFaker::Name.first_name)
           expect(widget.versions.last.previous).to be_instance_of(PaperTrail::Version)
         end
-      end
-    end
-
-    describe "#originator" do
-      it "delegates to paper_trail_originator" do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
-        version = PaperTrail::Version.new
-        allow(version).to receive(:paper_trail_originator)
-        version.originator
-        expect(version).to have_received(:paper_trail_originator)
-      end
-
-      it "displays a deprecation warning" do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
-        PaperTrail::Version.new.originator
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
-          with(/Use paper_trail_originator instead of originator/)
       end
     end
 
@@ -169,7 +154,7 @@ module PaperTrail
               }.to raise_error(ArgumentError)
             end
 
-            context "`serializer == YAML`" do
+            context "YAML serializer" do
               it "locates versions according to their `object` contents" do
                 expect(PaperTrail.serializer).to be PaperTrail::Serializers::YAML
                 widget.update_attributes!(name: name, an_integer: int)
@@ -208,12 +193,6 @@ module PaperTrail
           end
 
           describe "#where_object_changes", versioning: true do
-            before do
-              widget.update_attributes!(name: name, an_integer: 0)
-              widget.update_attributes!(name: "foobar", an_integer: 100)
-              widget.update_attributes!(name: FFaker::Name.last_name, an_integer: int)
-            end
-
             it "requires its argument to be a Hash" do
               expect {
                 PaperTrail::Version.where_object_changes(:foo)
@@ -223,14 +202,13 @@ module PaperTrail
               }.to raise_error(ArgumentError)
             end
 
-            context "YAML serializer" do
-              before do
-                unless column_datatype_override
-                  allow(ActiveSupport::Deprecation).to receive(:warn)
-                end
-              end
-
-              it "locates versions according to their `object_changes` contents" do
+            # Only test json and jsonb columns. where_object_changes no longer
+            # supports text columns.
+            if column_datatype_override
+              it "locates versions according to their object_changes contents" do
+                widget.update_attributes!(name: name, an_integer: 0)
+                widget.update_attributes!(name: "foobar", an_integer: 100)
+                widget.update_attributes!(name: FFaker::Name.last_name, an_integer: int)
                 expect(
                   widget.versions.where_object_changes(name: name)
                 ).to eq(widget.versions[0..1])
@@ -240,49 +218,15 @@ module PaperTrail
                 expect(
                   widget.versions.where_object_changes(an_integer: int)
                 ).to eq([widget.versions.last])
-                unless column_datatype_override
-                  expect(ActiveSupport::Deprecation).to have_received(:warn).
-                    exactly(3).times.with(/^where_object_changes/)
-                end
-              end
-
-              it "handles queries for multiple attributes" do
                 expect(
                   widget.versions.where_object_changes(an_integer: 100, name: "foobar")
                 ).to eq(widget.versions[1..2])
-                unless column_datatype_override
-                  expect(ActiveSupport::Deprecation).to have_received(:warn).
-                    at_least(:once).with(/^where_object_changes/)
-                end
               end
-            end
-
-            # Only test the JSON serializer against where_object_changes
-            # for json and jsonb columns, not for text columns, which are
-            # no longer supported.
-            if column_datatype_override
-              context "JSON serializer" do
-                before do
-                  PaperTrail.serializer = PaperTrail::Serializers::JSON
-                end
-
-                it "locates versions according to their `object_changes` contents" do
-                  expect(
-                    widget.versions.where_object_changes(name: name)
-                  ).to eq(widget.versions[0..1])
-                  expect(
-                    widget.versions.where_object_changes(an_integer: 100)
-                  ).to eq(widget.versions[1..2])
-                  expect(
-                    widget.versions.where_object_changes(an_integer: int)
-                  ).to eq([widget.versions.last])
-                end
-
-                it "handles queries for multiple attributes" do
-                  expect(
-                    widget.versions.where_object_changes(an_integer: 100, name: "foobar")
-                  ).to eq(widget.versions[1..2])
-                end
+            else
+              it "raises error" do
+                expect {
+                  widget.versions.where_object_changes(name: "foo").to_a
+                }.to(raise_error(/no longer supports reading YAML from a text column/))
               end
             end
           end

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Widget, type: :model do
@@ -18,24 +20,6 @@ RSpec.describe Widget, type: :model do
       expect(widget).to have_a_version_with name: "Leonard", an_integer: 1
       expect(widget).to have_a_version_with an_integer: 1
       expect(widget).to have_a_version_with name: "Tom"
-    end
-  end
-
-  describe "`have_a_version_with_changes` matcher", versioning: true do
-    before do
-      widget.update_attributes!(name: "Leonard", an_integer: 2)
-      widget.update_attributes!(name: "Tom")
-      widget.update_attributes!(name: "Bob")
-    end
-
-    it "is possible to do assertions on version changes" do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
-      expect(widget).to have_a_version_with_changes name: "Leonard", an_integer: 2
-      expect(widget).to have_a_version_with_changes an_integer: 2
-      expect(widget).to have_a_version_with_changes name: "Tom"
-      expect(widget).to have_a_version_with_changes name: "Bob"
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
-        exactly(5).times.with(/^where_object_changes/)
     end
   end
 

--- a/spec/paper_trail/associations_spec.rb
+++ b/spec/paper_trail/associations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe(::PaperTrail, versioning: true) do

--- a/spec/paper_trail/attribute_serializers/object_attribute_spec.rb
+++ b/spec/paper_trail/attribute_serializers/object_attribute_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail

--- a/spec/paper_trail/cleaner_spec.rb
+++ b/spec/paper_trail/cleaner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail
@@ -16,16 +18,14 @@ module PaperTrail
 
     describe "track_associations?" do
       context "@track_associations is nil" do
-        after do
-          PaperTrail.config.track_associations = true
-        end
-
         it "returns false and prints a deprecation warning" do
           config = described_class.instance
           config.track_associations = nil
-          expect {
-            expect(config.track_associations?).to eq(false)
-          }.to output(/DEPRECATION WARNING/).to_stderr
+          expect(config.track_associations?).to eq(false)
+        end
+
+        after do
+          PaperTrail.config.track_associations = true
         end
       end
     end

--- a/spec/paper_trail/model_spec.rb
+++ b/spec/paper_trail/model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe(::PaperTrail, versioning: true) do

--- a/spec/paper_trail/serializer_spec.rb
+++ b/spec/paper_trail/serializer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/custom_json_serializer"
 

--- a/spec/paper_trail/serializers/custom_json_serializer_spec.rb
+++ b/spec/paper_trail/serializers/custom_json_serializer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_relative "../../support/custom_json_serializer"
 

--- a/spec/paper_trail/serializers/custom_yaml_serializer_spec.rb
+++ b/spec/paper_trail/serializers/custom_yaml_serializer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module CustomYamlSerializer

--- a/spec/paper_trail/serializers/json_spec.rb
+++ b/spec/paper_trail/serializers/json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail

--- a/spec/paper_trail/serializers/yaml_spec.rb
+++ b/spec/paper_trail/serializers/yaml_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail

--- a/spec/paper_trail/thread_safety_spec.rb
+++ b/spec/paper_trail/thread_safety_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe PaperTrail do

--- a/spec/paper_trail/version_concern_spec.rb
+++ b/spec/paper_trail/version_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/alt_db_init"
 

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail

--- a/spec/paper_trail/version_number_spec.rb
+++ b/spec/paper_trail/version_number_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail

--- a/spec/paper_trail/version_spec.rb
+++ b/spec/paper_trail/version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module PaperTrail

--- a/spec/paper_trail_spec.rb
+++ b/spec/paper_trail_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe PaperTrail do

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Articles management", type: :request, order: :defined do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] ||= "test"
 ENV["DB"] ||= "sqlite"
 

--- a/spec/support/alt_db_init.rb
+++ b/spec/support/alt_db_init.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file copies the test database into locations for the `Foo` and `Bar`
 # namespace, then defines those namespaces, then establishes the sqlite3
 # connection for the namespaces to simulate an application with multiple

--- a/spec/support/custom_json_serializer.rb
+++ b/spec/support/custom_json_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This custom serializer excludes nil values
 module CustomJsonSerializer
   extend PaperTrail::Serializers::JSON


### PR DESCRIPTION
- Use base class name for reification of associations
- Add explicit precision on datetime columns to enable fractional second precision on mysql