### PR TITLE
Fix sample migration from YAML to JSON column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,7 +1239,7 @@ add_column :versions, :new_object, :jsonb # or :json
 
 PaperTrail::Version.reset_column_information
 PaperTrail::Version.find_each do |version|
-  version.update_column :new_object, YAML.load(version.object)
+  version.update_column :new_object, YAML.load(version.object) if version.object
 end
 
 remove_column :versions, :object


### PR DESCRIPTION
Migration fails if version.object is null (for instance with a "create" action version).