### PR TITLE
No upper-bound dependency for AR

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -28,7 +28,7 @@ has been destroyed.
   s.required_ruby_version = ">= 2.3.0"
 
   # Rails does not follow semver, makes breaking changes in minor versions.
-  s.add_dependency "activerecord", [">= 4.2", "< 5.2"]
+  s.add_dependency "activerecord", ">= 4.2"
   s.add_dependency "request_store", "~> 1.1"
 
   s.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
These upper bound dependencies make it so that every time I go to upgrade a Rails version, I need to point to a fork of paper_trail until you guys release a new version. I don't see the major benefit of having an upper bound dependency. It just creates noise/busy work for you guys. If people have issues with newer versions of Rails they will report them.

In my project of ~100 gems, paper_trail and 2-3 others always come up when I go to do Rails upgrades for this reason

What do you guys think?