### PR TITLE
Add paper_trail.update_columns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -143,7 +143,3 @@ Style/ModuleFunction:
 # performance implications. Double quotes are slightly easier to read.
 Style/StringLiterals:
   EnforcedStyle: double_quotes
-
-Style/MethodCallWithoutArgsParentheses:
-  Exclude:
-    - lib/paper_trail/record_trail.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -143,3 +143,7 @@ Style/ModuleFunction:
 # performance implications. Double quotes are slightly easier to read.
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/MethodCallWithoutArgsParentheses:
+  Exclude:
+    - lib/paper_trail/record_trail.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- [#1037](https://github.com/airblade/paper_trail/pull/1037) Add `paper_trail.update_columns`
 
 ### Fixed
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -226,7 +226,7 @@ module PaperTrail
         data[:created_at] = @record.updated_at
       end
       if record_object_changes? && changed_notably?
-        data[:object_changes] = recordable_object_changes
+        data[:object_changes] = recordable_object_changes(changes)
       end
       add_transaction_id_to(data)
       merge_metadata_into(data)
@@ -300,7 +300,7 @@ module PaperTrail
         data[:created_at] = @record.updated_at
       end
       if record_object_changes?
-        data[:object_changes] = recordable_object_changes
+        data[:object_changes] = recordable_object_changes(changes)
       end
       add_transaction_id_to(data)
       merge_metadata_into(data)
@@ -348,7 +348,7 @@ module PaperTrail
     # otherwise the column is a `text` column, and we must perform the
     # serialization here, using `PaperTrail.serializer`.
     # @api private
-    def recordable_object_changes(changes = changes())
+    def recordable_object_changes(changes)
       if @record.class.paper_trail.version_class.object_changes_col_is_json?
         changes
       else

--- a/spec/models/on/empty_array_spec.rb
+++ b/spec/models/on/empty_array_spec.rb
@@ -21,6 +21,15 @@ module On
       end
     end
 
+    describe ".paper_trail.update_columns" do
+      it "creates a version record" do
+        widget = Widget.create
+        assert_equal 1, widget.versions.length
+        widget.paper_trail.update_columns(name: "Bugle")
+        assert_equal 2, widget.versions.length
+      end
+    end
+
     describe "#update_attributes" do
       it "does not create any version records" do
         record = described_class.create(name: "Alice")

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -289,13 +289,13 @@ RSpec.describe Widget, type: :model do
     it "creates a version record" do
       widget = Widget.create
       expect(widget.versions.count).to eq(1)
-      Timecop.travel 1.second.since # because MySQL lacks fractional seconds precision
-      widget.paper_trail.update_columns(name: "Bugle")
-      # widget.update_attributes(name: "Bugle")
-      expect(widget.versions.count).to eq(2)
-      expect(widget.versions.last.event).to(eq("update"))
-      expect(widget.versions.last.changeset[:name]).to eq([nil, "Bugle"])
-      expect(widget.versions.last.created_at.to_i).to eq(Time.now.to_i)
+      Timecop.freeze Time.now do
+        widget.paper_trail.update_columns(name: "Bugle")
+        expect(widget.versions.count).to eq(2)
+        expect(widget.versions.last.event).to(eq("update"))
+        expect(widget.versions.last.changeset[:name]).to eq([nil, "Bugle"])
+        expect(widget.versions.last.created_at.to_i).to eq(Time.now.to_i)
+      end
     end
   end
 

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -285,6 +285,20 @@ RSpec.describe Widget, type: :model do
     end
   end
 
+  describe ".paper_trail.update_columns", versioning: true do
+    it "creates a version record" do
+      widget = Widget.create
+      expect(widget.versions.count).to eq(1)
+      Timecop.travel 1.second.since # because MySQL lacks fractional seconds precision
+      widget.paper_trail.update_columns(name: "Bugle")
+      # widget.update_attributes(name: "Bugle")
+      expect(widget.versions.count).to eq(2)
+      expect(widget.versions.last.event).to(eq("update"))
+      expect(widget.versions.last.changeset[:name]).to eq([nil, "Bugle"])
+      expect(widget.versions.last.created_at.to_i).to eq(Time.now.to_i)
+    end
+  end
+
   describe "#update", versioning: true do
     it "creates a version record" do
       widget = Widget.create


### PR DESCRIPTION
Add paper_trail.update_columns so you can record a version when using
`update_columns` (which skips all callbacks, including the `after_update`
callback).


