### PR TITLE
Raise helpful error when CVC is abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- [#961](https://github.com/airblade/paper_trail/issues/961) - Instead of
+  crashing when misconfigured Custom Version Classes are used, an error will be
+  raised earlier, with a much more helpful message.
 
 ### Fixed
 

--- a/spec/dummy_app/app/versions/abstract_version.rb
+++ b/spec/dummy_app/app/versions/abstract_version.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class AbstractVersion < ActiveRecord::Base
+  include PaperTrail::VersionConcern
+  self.abstract_class = true
+end

--- a/spec/paper_trail/model_config_spec.rb
+++ b/spec/paper_trail/model_config_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module PaperTrail
+  ::RSpec.describe ModelConfig do
+    describe "when has_paper_trail is called" do
+      it "raises an error" do
+        expect {
+          class MisconfiguredCVC < ActiveRecord::Base
+            has_paper_trail class_name: "AbstractVersion"
+          end
+        }.to raise_error(
+          /use concrete \(not abstract\) version models/
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of crashing when misconfigured Custom Version Classes are used, an error will be raised earlier, with a much more helpful message.

[Fixes #961]