### PR TITLE
Require AR and AS: require all and earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1042](https://github.com/airblade/paper_trail/issues/1042) - A rare issue
+  with load order when using PT outside of rails
 
 ## 8.1.2 (2017-12-22)
 

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
-require "active_support"
+# AR does not require all of AS, but PT does. PT uses core_ext like
+# `String#squish`, so we require `active_support/all`. Instead of eagerly
+# loading all of AS here, we could put specific `require`s in only the various
+# PT files that need them, but this seems easier to troubleshoot, though it may
+# add a few milliseconds to rails boot time. If that becomes a pain point, we
+# can revisit this decision.
+require "active_support/all"
+
+# AR is required for, eg. has_paper_trail.rb, so we could put this `require` in
+# all of those files, but it seems easier to troubleshoot if we just make sure
+# AR is loaded here before loading *any* of PT. See discussion of
+# performance/simplicity tradeoff for activesupport above.
+require "active_record"
+
 require "request_store"
 require "paper_trail/cleaner"
 require "paper_trail/config"

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/object" # provides the `try` method
 require "paper_trail/attribute_serializers/object_attribute"
 require "paper_trail/attribute_serializers/object_changes_attribute"
 require "paper_trail/model_config"

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext"
-
 module PaperTrail
   # Configures an ActiveRecord model, mostly at application boot time, but also
   # sometimes mid-request, with methods like enable/disable.

--- a/lib/paper_trail/serializers/json.rb
+++ b/lib/paper_trail/serializers/json.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/json"
-
 module PaperTrail
   module Serializers
     # An alternate serializer for, e.g. `versions.object`.

--- a/lib/paper_trail/version_association_concern.rb
+++ b/lib/paper_trail/version_association_concern.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
-
 module PaperTrail
   # Functionality for `PaperTrail::VersionAssociation`. Exists in a module
   # for the same reasons outlined in version_concern.rb.

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
 require "paper_trail/attribute_serializers/object_changes_attribute"
 require "paper_trail/queries/versions/where_object"
 require "paper_trail/queries/versions/where_object_changes"


### PR DESCRIPTION
Fixes a rare issue with load order when using PT outside of rails. (https://github.com/airblade/paper_trail/issues/1042)