### PR TITLE
Fix rare issue in touch_with_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
+- [#1047](https://github.com/airblade/paper_trail/issues/1047) - A rare issue
+  where `touch_with_version` saved less data than expected, but only when the
+  update callback was not installed, eg. `has_paper_trail(on: [])`
 - [#1042](https://github.com/airblade/paper_trail/issues/1042) - A rare issue
   with load order when using PT outside of rails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 - Removed deprecated `Version#originator`, use `#paper_trail_originator`
 - Using paper_trail.on_destroy(:after) with ActiveRecord's
   belongs_to_required_by_default will produce an error instead of a warning.
-- Removed `warn_about_not_setting_whodunnit` controller method. Please remove
-  callbacks like `skip_after_action :warn_about_not_setting_whodunnit`.
+- Removed the `warn_about_not_setting_whodunnit` controller method. This will
+  only be a problem for you if you are skipping it, eg.
+  `skip_after_action :warn_about_not_setting_whodunnit`, which few people did.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Add a `paper_trail_enabled_for_controller` method to your controller.
 ```ruby
 class ApplicationController < ActionController::Base
   def paper_trail_enabled_for_controller
+    # Don't omit `super` without a good reason.
     super && request.user_agent != 'Disable User-Agent'
   end
 end

--- a/lib/paper_trail/frameworks/rails/controller.rb
+++ b/lib/paper_trail/frameworks/rails/controller.rb
@@ -20,6 +20,8 @@ module PaperTrail
       #
       # Override this method in your controller to call a different
       # method, e.g. `current_person`, or anything you like.
+      #
+      # @api public
       def user_for_paper_trail
         return unless defined?(current_user)
         ActiveSupport::VERSION::MAJOR >= 4 ? current_user.try!(:id) : current_user.try(:id)
@@ -45,6 +47,8 @@ module PaperTrail
       # Use the `:meta` option to
       # `PaperTrail::Model::ClassMethods.has_paper_trail` to store any extra
       # model-level data you need.
+      #
+      # @api public
       def info_for_paper_trail
         {}
       end
@@ -54,6 +58,15 @@ module PaperTrail
       #
       # Override this method in your controller to specify when PaperTrail
       # should be off.
+      #
+      # ```
+      # def paper_trail_enabled_for_controller
+      #   # Don't omit `super` without a good reason.
+      #   super && request.user_agent != 'Disable User-Agent'
+      # end
+      # ```
+      #
+      # @api public
       def paper_trail_enabled_for_controller
         ::PaperTrail.enabled?
       end
@@ -62,11 +75,15 @@ module PaperTrail
 
       # Tells PaperTrail whether versions should be saved in the current
       # request.
+      #
+      # @api public
       def set_paper_trail_enabled_for_controller
         ::PaperTrail.request.enabled_for_controller = paper_trail_enabled_for_controller
       end
 
       # Tells PaperTrail who is responsible for any changes that occur.
+      #
+      # @api public
       def set_paper_trail_whodunnit
         if ::PaperTrail.request.enabled_for_controller?
           ::PaperTrail.request.whodunnit = user_for_paper_trail
@@ -75,6 +92,8 @@ module PaperTrail
 
       # Tells PaperTrail any information from the controller you want to store
       # alongside any changes that occur.
+      #
+      # @api public
       def set_paper_trail_controller_info
         if ::PaperTrail.request.enabled_for_controller?
           ::PaperTrail.request.controller_info = info_for_paper_trail

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -87,7 +87,10 @@ module PaperTrail
 
       @model_class.send(
         "#{recording_order}_destroy",
-        ->(r) { r.paper_trail.record_destroy if r.paper_trail.save_version? }
+        lambda do |r|
+          return unless r.paper_trail.save_version?
+          r.paper_trail.record_destroy(recording_order)
+        end
       )
 
       return if @model_class.paper_trail_options[:on].include?(:destroy)

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -105,7 +105,9 @@ module PaperTrail
         r.paper_trail.reset_timestamp_attrs_for_update_if_needed
       }
       @model_class.after_update { |r|
-        r.paper_trail.record_update(nil) if r.paper_trail.save_version?
+        if r.paper_trail.save_version?
+          r.paper_trail.record_update(force: false, in_after_callback: true)
+        end
       }
       @model_class.after_update { |r|
         r.paper_trail.clear_version_instance

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -63,6 +63,8 @@ module PaperTrail
     end
 
     # Adds a callback that records a version after a "create" event.
+    #
+    # @api public
     def on_create
       @model_class.after_create { |r|
         r.paper_trail.record_create if r.paper_trail.save_version?
@@ -72,6 +74,8 @@ module PaperTrail
     end
 
     # Adds a callback that records a version before or after a "destroy" event.
+    #
+    # @api public
     def on_destroy(recording_order = "before")
       unless %w[after before].include?(recording_order.to_s)
         raise ArgumentError, 'recording order can only be "after" or "before"'
@@ -91,6 +95,8 @@ module PaperTrail
     end
 
     # Adds a callback that records a version after an "update" event.
+    #
+    # @api public
     def on_update
       @model_class.before_save { |r|
         r.paper_trail.reset_timestamp_attrs_for_update_if_needed

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -257,7 +257,11 @@ module PaperTrail
       merge_metadata_into(data)
     end
 
-    def record_destroy
+    # `recording_order` is "after" or "before". See ModelConfig#on_destroy.
+    #
+    # @api private
+    def record_destroy(recording_order)
+      @in_after_callback = recording_order == "after"
       if enabled? && !@record.new_record?
         version = @record.class.paper_trail.version_class.create(data_for_destroy)
         if version.errors.any?
@@ -269,6 +273,8 @@ module PaperTrail
           save_associations(version)
         end
       end
+    ensure
+      @in_after_callback = false
     end
 
     # Returns data for record destroy

--- a/spec/models/on/empty_array_spec.rb
+++ b/spec/models/on/empty_array_spec.rb
@@ -17,7 +17,9 @@ module On
         record = described_class.create(name: "Alice")
         record.paper_trail.touch_with_version
         expect(record.versions.length).to(eq(1))
-        expect(record.versions.first.event).to(eq("update"))
+        v = record.versions.first
+        expect(v.event).to(eq("update"))
+        expect(v.object_deserialized.fetch("name")).to eq("Alice")
       end
     end
 


### PR DESCRIPTION
Fixes a rare issue where `touch_with_version` saved less data than expected, but only when the update callback was not installed, eg. `has_paper_trail(on: [])`.

- Supersedes https://github.com/airblade/paper_trail/pull/1048
- Fixes https://github.com/airblade/paper_trail/issues/1047
