### PR TITLE
Move without_versioning to model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Deprecated
 
+- [#1064](https://github.com/airblade/paper_trail/pull/1064) - `without_versioning` has
+  now been moved to the model eg. `MyModel.paper_trail.without_versioning` and the old way,
+  `my_instance.paper_trail.without_versioning` is deprecated. Behaviour remains unchanged except 
+  that it no longer accepts a method name, it only accepts a block.
 - [#1063](https://github.com/airblade/paper_trail/pull/1063) -
   `paper_trail.touch_with_version` is deprecated in favor of `touch`.
 - [#1033](https://github.com/airblade/paper_trail/pull/1033) - Request variables
@@ -36,6 +40,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
+- [#1064](https://github.com/airblade/paper_trail/pull/1064) - `without_versioning` has
+  now been added to the model eg. `MyModel.paper_trail.without_versioning`
 - [#1033](https://github.com/airblade/paper_trail/pull/1033) -
   Set request variables temporarily using a block, eg.
   `PaperTrail.request(whodunnit: 'Jared') do .. end`

--- a/README.md
+++ b/README.md
@@ -502,18 +502,16 @@ PaperTrail.request.enable_model(Widget)
 PaperTrail.request.disable_model(Widget)
 ```
 
-This setting, as with all `PaperTrail.request` settings, affects only the
-current request, not all threads.
-
-#### Per Method
-
-You can call a method without creating a new version using `without_versioning`.
+Or in a block by using `without_versioning`
 
 ```ruby
 Widget.paper_trail.without_versioning do
   @widget.update_attributes name: 'Ford'
 end
 ```
+
+These methods (including `without_versioning`), as with all `PaperTrail.request` 
+settings, affects only the current request, not all threads.
 
 ### 2.e. Limiting the Number of Versions Created
 

--- a/README.md
+++ b/README.md
@@ -508,13 +508,6 @@ current request, not all threads.
 #### Per Method
 
 You can call a method without creating a new version using `without_versioning`.
- It takes either a method name as a symbol:
-
-```ruby
-Widget.paper_trail.without_versioning :destroy
-```
-
-Or a block:
 
 ```ruby
 Widget.paper_trail.without_versioning do

--- a/README.md
+++ b/README.md
@@ -511,19 +511,16 @@ You can call a method without creating a new version using `without_versioning`.
  It takes either a method name as a symbol:
 
 ```ruby
-@widget.paper_trail.without_versioning :destroy
+Widget.paper_trail.without_versioning :destroy
 ```
 
 Or a block:
 
 ```ruby
-@widget.paper_trail.without_versioning do
+Widget.paper_trail.without_versioning do
   @widget.update_attributes name: 'Ford'
 end
 ```
-
-During `without_versioning`, PaperTrail is disabled for the whole model
-(e.g. `Widget`), not just for the instance (e.g. `@widget`).
 
 ### 2.e. Limiting the Number of Versions Created
 

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -142,6 +142,18 @@ module PaperTrail
       @_version_class ||= @model_class.version_class_name.constantize
     end
 
+    # Executes the given block without creating any new versions for that model.
+    #
+    # @api public
+    def without_versioning
+      paper_trail_was_enabled = PaperTrail.request.enabled_for_model?(@model_class)
+      PaperTrail.request.disable_model(@model_class)
+
+      yield
+    ensure
+      PaperTrail.request.enable_model(@model_class) if paper_trail_was_enabled
+    end
+
     private
 
     def active_record_gem_version

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -7,12 +7,14 @@ module PaperTrail
       my_model_instance.paper_trail.whodunnit('John') is deprecated,
       please use PaperTrail.request(whodunnit: 'John')
     STR
-
     DPR_TOUCH_WITH_VERSION = <<-STR.squish.freeze
       my_model_instance.paper_trail.touch_with_version is deprecated,
       please use my_model_instance.touch
     STR
-
+    DPR_WITHOUT_VERSIONING = <<-STR.squish.freeze
+      my_model_instance.paper_trail.without_versioning is deprecated,
+      please use MyModel.paper_trail.without_versioning
+    STR
     RAILS_GTE_5_1 = ::ActiveRecord.gem_version >= ::Gem::Version.new("5.1.0.beta1")
 
     def initialize(record)
@@ -479,7 +481,7 @@ module PaperTrail
       attributes.each { |column|
         @record.send(:write_attribute, column, current_time)
       }
-      @record.paper_trail.without_versioning do
+      @record.class.paper_trail.without_versioning do
         @record.save!(validate: false)
       end
       record_update(force: true, in_after_callback: false)
@@ -524,6 +526,7 @@ module PaperTrail
 
     # Executes the given method or block without creating a new version.
     def without_versioning(method = nil)
+      ::ActiveSupport::Deprecation.warn(DPR_WITHOUT_VERSIONING, caller(1))
       paper_trail_was_enabled = PaperTrail.request.enabled_for_model?(@record.class)
       PaperTrail.request.disable_model(@record.class)
       if method

--- a/lib/paper_trail/request.rb
+++ b/lib/paper_trail/request.rb
@@ -150,6 +150,25 @@ module PaperTrail
         who.respond_to?(:call) ? who.call : who
       end
 
+      # Executes the given method or block without creating a new version.
+      #
+      # @api public
+      def without_versioning(method = nil)
+        paper_trail_was_enabled = PaperTrail.request.enabled?
+        PaperTrail.request.disable_all
+        if method
+          if respond_to?(method)
+            public_send(method)
+          else
+            @record.send(method)
+          end
+        else
+          yield @record
+        end
+      ensure
+        PaperTrail.request.enable_all if paper_trail_was_enabled
+      end
+
       private
 
       # Returns a Hash, initializing with default values if necessary.

--- a/spec/paper_trail/model_spec.rb
+++ b/spec/paper_trail/model_spec.rb
@@ -342,8 +342,10 @@ RSpec.describe(::PaperTrail, versioning: true) do
 
       context "when destroyed \"without versioning\"" do
         it "leave paper trail off after call" do
+          allow(::ActiveSupport::Deprecation).to receive(:warn)
           @widget.paper_trail.without_versioning(:destroy)
           expect(::PaperTrail.request.enabled_for_model?(Widget)).to eq(false)
+          expect(::ActiveSupport::Deprecation).to have_received(:warn).once
         end
       end
 
@@ -362,6 +364,7 @@ RSpec.describe(::PaperTrail, versioning: true) do
 
         context "when updated \"without versioning\"" do
           before do
+            allow(::ActiveSupport::Deprecation).to receive(:warn)
             @widget.paper_trail.without_versioning do
               @widget.update_attributes(name: "Ford")
             end
@@ -372,10 +375,12 @@ RSpec.describe(::PaperTrail, versioning: true) do
 
           it "not create new version" do
             expect(@widget.versions.length).to(eq(@count))
+            expect(::ActiveSupport::Deprecation).to have_received(:warn).twice
           end
 
           it "enable paper trail after call" do
             expect(PaperTrail.request.enabled_for_model?(Widget)).to eq(true)
+            expect(::ActiveSupport::Deprecation).to have_received(:warn).twice
           end
         end
 
@@ -386,6 +391,7 @@ RSpec.describe(::PaperTrail, versioning: true) do
             expect(::ActiveSupport::Deprecation).to have_received(:warn).once
             expect(@widget.versions.length).to(eq(@count))
             expect(::PaperTrail.request.enabled_for_model?(Widget)).to eq(true)
+            expect(::ActiveSupport::Deprecation).to have_received(:warn).once
           end
         end
       end
@@ -988,6 +994,19 @@ RSpec.describe(::PaperTrail, versioning: true) do
     end
 
     it "not have a version created on destroy" do
+      expect(@widget.versions.empty?).to(eq(true))
+    end
+  end
+
+  context "a model" do
+    before do
+      @widget = Widget.new
+    end
+
+    it "not have a version when used within without_versioning" do
+      Widget.paper_trail.without_versioning do
+        @widget.save!
+      end
       expect(@widget.versions.empty?).to(eq(true))
     end
   end

--- a/spec/paper_trail/thread_safety_spec.rb
+++ b/spec/paper_trail/thread_safety_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PaperTrail do
     it "is thread-safe" do
       enabled = nil
       t1 = Thread.new do
-        Widget.new.paper_trail.without_versioning do
+        Widget.paper_trail.without_versioning do
           sleep(0.01)
           enabled = described_class.request.enabled_for_model?(Widget)
           sleep(0.01)


### PR DESCRIPTION
The current implementation of`without_versioning` is incorrectly set as an instance method when it should be part of the class which the current behaviour clearly shows. This PR fixes this and deprecates the old behavior.

The only difference with the new method is that it no longer accepts a method name, as its on the class not the instance. I didnt want to add this to the new implementation because I believe it is an unnecessary addition to the API.

This was somewhat related to Issue #916

