### PR TITLE
Add PaperTrail.request.without_versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
+- [#1065](https://github.com/airblade/paper_trail/pull/1065) - `without_versioning` has
+  now been added to the request eg. `PaperTrail.request.without_versioning do .. end`
+- [#1065](https://github.com/airblade/paper_trail/pull/1065) - `enabled_for_all_models?`, `enabled_for_all_models(bool)`, `enable_for_all_models`, `disable_for_all_models` have now been added to the request eg. `PaperTrail.request.enabled_for_all_models?` etc.
 - [#1033](https://github.com/airblade/paper_trail/pull/1033) -
   Set request variables temporarily using a block, eg.
   `PaperTrail.request(whodunnit: 'Jared') do .. end`

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@
 
 source "https://rubygems.org"
 gemspec
+
+gem "rails-controller-testing"

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@
 
 source "https://rubygems.org"
 gemspec
-
-gem "rails-controller-testing"

--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ config.paper_trail.enabled = false
 
 #### Per Request
 
+##### For Controllers
+
 Add a `paper_trail_enabled_for_controller` method to your controller.
 
 ```ruby
@@ -489,7 +491,23 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-#### Per Class
+##### For All Models
+
+```ruby
+PaperTrail.request.enable_all_models
+PaperTrail.request.disable_all_models
+```
+
+Or a within a block using `without_versioning`:
+
+```ruby
+PaperTrail.request.without_versioning do
+  @widget.update_attributes(name: 'Ford')
+  @post.update_attributes(name: "Chevy vs Ford")
+end
+```
+
+##### Per Class
 
 ```ruby
 PaperTrail.request.enable_model(Widget)
@@ -499,7 +517,7 @@ PaperTrail.request.disable_model(Widget)
 This setting, as with all `PaperTrail.request` settings, affects only the
 current request, not all threads.
 
-#### Per Method
+##### Per Method
 
 You can call a method without creating a new version using `without_versioning`.
  It takes either a method name as a symbol:

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -108,6 +108,7 @@ module PaperTrail
     def enabled?
       PaperTrail.enabled? &&
         PaperTrail.request.enabled_for_controller? &&
+        PaperTrail.request.enabled_for_all_models? &&
         PaperTrail.request.enabled_for_model?(@record.class)
     end
 

--- a/lib/paper_trail/request.rb
+++ b/lib/paper_trail/request.rb
@@ -84,6 +84,43 @@ module PaperTrail
           !!store.fetch(:"enabled_for_#{model}", true)
       end
 
+      # Switches PaperTrail off for all models in the curent request.
+      # @api public
+      def disable_all_models
+        enabled_for_all_models(false)
+      end
+
+      # Switches PaperTrail on for all models in the current request.
+      # @api public
+      def enable_all_models
+        enabled_for_all_models(true)
+      end
+
+      # Sets whether PaperTrail is enabled or disabled for all models in the
+      # current request.
+      # @api public
+      def enabled_for_all_models(value)
+        store[:enabled_for_all_models] = value
+      end
+
+      # Returns `true` if PaperTrail is enabled for all models in this current
+      # request, `false` otherwise.
+      # @api public
+      def enabled_for_all_models?
+        !!store.fetch(:enabled_for_all_models, true)
+      end
+
+      # Executes the given block without creating any new versions for all models.
+      # @api public
+      def without_versioning
+        paper_trail_was_enabled = PaperTrail.request.enabled_for_all_models?
+        PaperTrail.request.disable_all_models
+
+        yield
+      ensure
+        PaperTrail.request.enable_all_models if paper_trail_was_enabled
+      end
+
       # @api private
       def merge(options)
         options.to_h.each do |k, v|


### PR DESCRIPTION
This PR is related to Issue #916. 

It adds the following methods:

```
PaperTrail.request.without_versioning do
end

PaperTrail.request.enabled_for_all_models?
PaperTrail.request.enabled_for_all_models(bool)
PaperTrail.request.enable_for_all_models
PaperTrail.request.disable_for_all_models
```