### PR TITLE
PaperTrail.request { } should return the value of the block to aid in passive wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Breaking Changes
 
-- None
+- `PaperTrail.request do ... end` now returns whatever value is returned from the given block. For example:
+``` ruby
+raise PaperTrail.request(whodunnit: "Michael Bay") do
+  ApplicationError
+end
+# => ApplicationError has been raised!
+```
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Breaking Changes
 
-- `PaperTrail.request do ... end` now returns whatever value is returned from the given block. For example:
-``` ruby
-raise PaperTrail.request(whodunnit: "Michael Bay") do
-  ApplicationError
-end
-# => ApplicationError has been raised!
-```
+- `PaperTrail.request do ... end` now returns whatever value is returned from the given block. 
 
 ### Added
 

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -135,7 +135,6 @@ module PaperTrail
         Request
       else
         Request.with(options, &block)
-        nil
       end
     end
 

--- a/spec/paper_trail_spec.rb
+++ b/spec/paper_trail_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe PaperTrail do
   describe ".request" do
-    it "returns the value returned by the block"
+    it "returns the value returned by the block" do
       expect(described_class.request { "A test" }).to eq("A test")
     end
   end

--- a/spec/paper_trail_spec.rb
+++ b/spec/paper_trail_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe PaperTrail do
   describe ".request" do
     it "returns the value returned by the block" do
-      expect(described_class.request { "A test" }).to eq("A test")
+      expect(described_class.request(whodunnit: "abe lincoln") { "A test" }).to eq("A test")
     end
   end
 

--- a/spec/paper_trail_spec.rb
+++ b/spec/paper_trail_spec.rb
@@ -3,6 +3,12 @@
 require "spec_helper"
 
 RSpec.describe PaperTrail do
+  describe ".request" do
+    it "returns the value returned by the block"
+      expect(described_class.request { "A test" }).to eq("A test")
+    end
+  end
+
   describe "#config", versioning: true do
     it "allows for config values to be set" do
       expect(described_class.config.enabled).to eq(true)


### PR DESCRIPTION
So I just spent the last 3 hours debugging because (ultimately) I had overwritten a method that some library depended on and I assumed that the below would be passively wrapping:

``` ruby
def valid_for_authentication?(*)
  PaperTrail.request(whodunnit: "The Machine") do
    super
  end
end
```

Turns out it doesn't, because it's forced to return nil.