### PR TITLE
Bypass check of the read-only attribute during reifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1467](https://github.com/paper-trail-gem/paper_trail/issues/1467) - Rails 7.1
+  enables ActiveRecord.raise_on_assign_to_attr_readonly so that writing to a
+  attr_readonly raises an exception. Bypass this behavior has been added.
 
 ## 17.0.0 (2025-10-24)
 

--- a/lib/paper_trail/attribute_readonly_bypass.rb
+++ b/lib/paper_trail/attribute_readonly_bypass.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module PaperTrail
+  # Provides functionality to temporarily bypass ActiveRecord's readonly attribute checks
+  # in a thread-safe manner.
+  #
+  # When `raise_on_assign_to_attr_readonly` is set to true in ActiveRecord configuration,
+  # setting a value to an attribute marked as `attr_readonly` will raise an exception.
+  # see. https://github.com/rails/rails/blob/86eb00986e1b5030f8b1d67d61f080800f1ae5a0/activerecord/lib/active_record/readonly_attributes.rb
+  #
+  # This module allows temporarily bypassing this check by making _attr_readonly return
+  # an empty array for specific threads while preserving the original behavior for other threads.
+  #
+  # @api private
+  module AttributeReadonlyBypass
+    # Instance variable name to track if bypass module has been installed
+    BYPASS_INSTALLED_IVAR = :@paper_trail_readonly_bypass_installed
+
+    # Thread-local variable key for storing bypass list
+    THREAD_BYPASS_KEY = :paper_trail_bypass_readonly
+
+    class << self
+      # Temporarily bypass readonly attribute check for the current thread
+      #
+      # @param model [ActiveRecord::Base] The model instance to bypass readonly checks for
+      # @yield The block to execute with readonly checks bypassed
+      # @return The result of the yielded block
+      def with_bypass!(model)
+        return yield unless model.class.respond_to?(:_attr_readonly)
+
+        enable_bypass(model.class)
+        add_to_thread_bypass_list(model.class)
+
+        yield
+      ensure
+        remove_from_thread_bypass_list(model.class)
+      end
+
+      private
+
+      # Enable readonly bypass by prepending EmptyReadonlyAttributes module
+      def enable_bypass(klass)
+        return if klass.instance_variable_get(BYPASS_INSTALLED_IVAR)
+
+        klass.singleton_class.prepend(EmptyReadonlyAttributes)
+        klass.instance_variable_set(BYPASS_INSTALLED_IVAR, true)
+      end
+
+      # Add model class to thread-local bypass list
+      def add_to_thread_bypass_list(klass)
+        Thread.current[THREAD_BYPASS_KEY] ||= Set.new
+        Thread.current[THREAD_BYPASS_KEY] << klass
+      end
+
+      # Remove model class from thread-local bypass list
+      def remove_from_thread_bypass_list(klass)
+        Thread.current[THREAD_BYPASS_KEY]&.delete(klass)
+      end
+    end
+
+    # Module that overrides _attr_readonly to return an empty array for bypassing threads
+    # while preserving the original value for other threads.
+    # This module is prepended to the singleton class to override the class method.
+    module EmptyReadonlyAttributes
+      def _attr_readonly
+        if bypassed?
+          []
+        else
+          super
+        end
+      end
+
+      private
+
+      # Check if current thread should bypass readonly check
+      def bypassed?
+        Thread.current[AttributeReadonlyBypass::THREAD_BYPASS_KEY]&.include?(self)
+      end
+    end
+  end
+end

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "paper_trail/attribute_serializers/object_attribute"
+require "paper_trail/attribute_readonly_bypass"
 
 module PaperTrail
   # Given a version record and some options, builds a new model object.
@@ -92,7 +93,9 @@ module PaperTrail
       # @api private
       def reify_attribute(k, v, model, version)
         if model.has_attribute?(k)
-          model[k.to_sym] = v
+          AttributeReadonlyBypass.with_bypass!(model) do
+            model[k.to_sym] = v
+          end
         elsif model.respond_to?(:"#{k}=")
           model.send(:"#{k}=", v)
         elsif version.logger

--- a/spec/dummy_app/app/models/chair.rb
+++ b/spec/dummy_app/app/models/chair.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Chair < ApplicationRecord
+  has_paper_trail
+end

--- a/spec/dummy_app/app/models/chair_with_readonly.rb
+++ b/spec/dummy_app/app/models/chair_with_readonly.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChairWithReadonly < ApplicationRecord
+  self.table_name = "chairs"
+
+  has_paper_trail
+  attr_readonly :id
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -394,6 +394,10 @@ class SetUpTestTables < ActiveRecord::Migration::Current
     end
 
     create_table :users, force: true
+
+    create_table :chairs, force: true do |t|
+      t.string :color
+    end
   end
 
   def down

--- a/spec/models/chair_spec.rb
+++ b/spec/models/chair_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Chair, :versioning do
+  context "with raise_on_assign_to_attr_readonly enabled" do
+    around do |example|
+      # Temporarily enable the config
+      original_value = ActiveRecord.raise_on_assign_to_attr_readonly
+      ActiveRecord.raise_on_assign_to_attr_readonly = true
+
+      example.run
+    ensure
+      ActiveRecord.raise_on_assign_to_attr_readonly = original_value
+    end
+
+    def create_versioned_record(klass)
+      record = klass.create
+      # To enable reify execution, the version object must not be nil.
+      # Additionally, since ActiveRecord.raise_on_assign_to_attr_readonly
+      # only applies to persisted objects, avoid using destroy with klass.new
+      # and instead use the update method.
+      record.update(color: "red")
+      raise "Setup failed: versions not created" unless record.versions.count == 2
+      raise "Setup failed: object is nil" if record.versions.last.object.nil?
+
+      record
+    end
+
+    let(:chair) { create_versioned_record(described_class) }
+    let(:chair_with_readonly) { create_versioned_record(ChairWithReadonly) }
+
+    context "without bypass" do
+      before do
+        allow(PaperTrail::AttributeReadonlyBypass).to receive(:with_bypass!).and_yield
+      end
+
+      it "does not raise when reifying Chair without attr_readonly" do
+        chair = create_versioned_record(described_class)
+        expect { chair.versions.last.reify }.not_to raise_error
+      end
+
+      # When raise_on_assign_to_attr_readonly is enabled and we reify to a previous state,
+      # it would raise an error because reify attempts to assign the readonly attribute
+      # to the existing record loaded from the database
+      it "raises when reifying a model with attr_readonly" do
+        expect { chair_with_readonly.versions.last.reify }.to raise_error(ActiveRecord::ReadonlyAttributeError)
+      end
+    end
+
+    context "with bypass" do
+      it "does not raise when reifying Chair without attr_readonly" do
+        expect { chair.versions.last.reify }.not_to raise_error
+      end
+
+      it "does not raise when reifying a model with attr_readonly" do
+        expect { chair_with_readonly.versions.last.reify }.not_to raise_error
+      end
+
+      it "is thread-safe and does not affect other threads" do
+        errors = []
+        threads = []
+
+        # Thread that reifies the model (bypasses readonly check)
+        5.times do |i|
+          threads << Thread.new do
+            10.times do
+              chair_with_readonly.versions.last.reify
+            rescue StandardError => e
+              errors << "Reify thread #{i}: #{e.class}: #{e.message}"
+            end
+          end
+        end
+
+        # Thread that checks _attr_readonly while others are reifying
+        # Should always see the original readonly attributes, never empty
+        threads << Thread.new do
+          50.times do
+            readonly_attrs = ChairWithReadonly._attr_readonly
+            if readonly_attrs.empty?
+              errors << "Checker thread: _attr_readonly was empty!"
+            end
+            sleep 0.001
+          end
+        end
+
+        threads.each(&:join)
+        expect(errors).to be_empty, "Thread safety issues detected: #{errors.join(', ')}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR resolves issue #1467 by bypassing check of the read-only attribute.

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
